### PR TITLE
Refresh coverage badge on push to main

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -1,8 +1,13 @@
 name: Code Coverage Workflow
 
-# Run the unit tests pipeline on pull requests to main, and all commits on all branches
+# Run the coverage pipeline on pull requests to main (to compute coverage and
+# post the PR comment), and on pushes to main (to refresh the committed badge
+# once a PR is merged, since the README references coverage.svg on main).
 on:
   pull_request:
+    branches: [ main ]
+
+  push:
     branches: [ main ]
 
 # Allow for the job to be ran manually from the GitHub Actions UI
@@ -63,9 +68,12 @@ jobs:
       with:
         files: coverage.svg
 
-    # Skip on pull_request runs: pushing a new commit to the PR branch becomes
-    # the PR's HEAD, but no workflow runs against it (GITHUB_TOKEN pushes don't
-    # trigger workflows), leaving the required status check pending forever.
+    # Commit the refreshed badge on push-to-main (after a PR merges) and on
+    # manual dispatch. Skip on pull_request runs: pushing a new commit to the PR
+    # branch becomes the PR's HEAD, but no workflow runs against it (GITHUB_TOKEN
+    # pushes don't trigger workflows), leaving the required status check pending
+    # forever. Pushing the badge commit to main is safe for the same reason -- it
+    # does not re-trigger this workflow, so there is no commit loop.
     - name: Commit badge
       if: steps.changed-files.outputs.files_changed == 'true' && github.event_name != 'pull_request'
       run: |


### PR DESCRIPTION
## Problem

The coverage badge (`coverage.svg`) stopped updating after PRs merge. The README references the badge **on the `main` branch**:

```
https://raw.githubusercontent.com/averylhammond/FishbowlInvoiceTool/main/coverage.svg
```

…but the coverage workflow only triggered on `pull_request` and `workflow_dispatch`, and its "Commit badge" step intentionally skips `pull_request` events:

```yaml
if: ... && github.event_name != 'pull_request'
```

That skip is correct and necessary — a `GITHUB_TOKEN` push to a PR branch doesn't trigger a new workflow run, which would leave the required status check stuck pending forever. But the side effect was that **nothing ever committed the refreshed badge**: not on PRs (skipped), and not on merge (no `push` trigger existed). The badge only updated via a manual `workflow_dispatch` run.

## Fix

Add a `push: branches: [main]` trigger. After a PR merges, the workflow recomputes coverage and commits the updated `coverage.svg` to `main`, exactly where the README points. The existing `github.event_name != 'pull_request'` guard already allows the commit on push events.

This is loop-safe: a `GITHUB_TOKEN` push (the badge commit) does not re-trigger workflows, so the push-to-main run won't spawn another run. The commit step only runs when `coverage.svg` actually changed.

## Test plan

- After merge, check the **Code Coverage Workflow** run for the push-to-main event and confirm an "Updated coverage.svg" commit lands on `main` when coverage changed.
- Confirm the README badge reflects the new percentage.
- Note: the badge won't visibly change until a PR that alters coverage merges — e.g. #39 (InvoiceAppController tests). Merge order: this PR first, then coverage-changing PRs will refresh the badge on their merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)