### PR TITLE
Modernize file path handling with pathlib and graceful failure (closes #35)

### DIFF
--- a/source/InvoiceAppController.py
+++ b/source/InvoiceAppController.py
@@ -1,4 +1,6 @@
 # Import necessary classes from modules
+from pathlib import Path
+
 from source.InvoiceAppDisplay import InvoiceAppDisplay
 from source.InvoiceAppFileIO import InvoiceAppFileIO
 from source.InvoiceProcessor import InvoiceProcessor
@@ -45,6 +47,11 @@ class InvoiceAppController:
             process_callback=self.handle_process_invoice,
         )
 
+        # Wire the GUI's error popup into the File IO Controller so file I/O failures
+        # surface to the user without coupling file I/O to the GUI. This must happen
+        # before the config files are parsed below so parse failures can be reported.
+        self.file_io_controller.report_error = self.display.show_error_popup
+
         # Use the File IO Controller to read in the criteria/exclusions for each cost section
         self.file_io_controller.parse_cost_criteria_file()
 
@@ -81,12 +88,12 @@ class InvoiceAppController:
     ###########################################################################
     ###          InvoiceAppController -> handle_process_invoice()           ###
     ###########################################################################
-    def handle_process_invoice(self, invoice_filepath: str, append_output: bool):
+    def handle_process_invoice(self, invoice_filepath: Path, append_output: bool):
         """
         Directs components to process the invoice located at invoice_filepath
 
         Args:
-            invoice_filepath (str): The filepath of the invoice PDF to be processed.
+            invoice_filepath (Path): The filepath of the invoice PDF to be processed.
             append_output (bool): Whether to append the Invoice outputs to any existing outputs.
                                     True: append to existing results.txt and output box
                                     False: overwrite existing results.txt and output box
@@ -103,7 +110,7 @@ class InvoiceAppController:
         if not invoice.page_contents or invoice.page_contents[0] is None:
             self.display.show_error_popup(
                 error_title="Error",
-                error_message="No pages were found in the invoice PDF located at {invoice_filepath}.",
+                error_message=f"No pages were found in the invoice PDF located at {invoice_filepath}.",
             )
             return
 

--- a/source/InvoiceAppDisplay.py
+++ b/source/InvoiceAppDisplay.py
@@ -306,9 +306,9 @@ class InvoiceAppDisplay(tk.Tk):
 
         """
 
-        # Open a file dialog to select a PDF invoice file
+        # Open a file dialog to select a PDF invoice file (Tk requires a str path)
         file_path = filedialog.askopenfilename(
-            initialdir=INVOICES_PATH,
+            initialdir=str(INVOICES_PATH),
             title="Select Invoice PDF",
             filetypes=[("PDF files", "*.pdf")],  # Filter for PDF files only
         )
@@ -364,9 +364,10 @@ class InvoiceAppDisplay(tk.Tk):
             )
             return
 
-        # Forward the call to the process_callback function with the selected file path. Append output is false to reset the
-        # output windows and results.txt file since this is the only invoice being processed
-        self.process_callback(file_path, append_output=False)
+        # Forward the call to the process_callback function with the selected file path as a Path.
+        # Append output is false to reset the output windows and results.txt file since this is the
+        # only invoice being processed
+        self.process_callback(Path(file_path), append_output=False)
 
     ###########################################################################
     ###         InvoiceAppDisplay -> handle_process_all_invoices()          ###
@@ -380,7 +381,7 @@ class InvoiceAppDisplay(tk.Tk):
 
         try:
             # Loop through all invoice files in the invoices directory and process each one
-            for file_path in Path(INVOICES_PATH).resolve().iterdir():
+            for file_path in INVOICES_PATH.resolve().iterdir():
 
                 # Process each invoice, appending output to the results.txt file and output widget
                 self.process_callback(file_path, append_output=True)
@@ -456,7 +457,7 @@ class InvoiceAppDisplay(tk.Tk):
         Opens the results log file in the system default text editor if it exists.
         Shows an error popup if the file has not been created yet.
         """
-        if Path(RESULTS_LOG_PATH).exists():
+        if RESULTS_LOG_PATH.exists():
             open_in_system_editor(RESULTS_LOG_PATH)
         else:
             self.show_error_popup(
@@ -472,7 +473,7 @@ class InvoiceAppDisplay(tk.Tk):
         Opens the debug log file in the system default text editor if it exists.
         Shows an error popup if the file has not been created yet.
         """
-        if Path(DEBUG_LOG_PATH).exists():
+        if DEBUG_LOG_PATH.exists():
             open_in_system_editor(DEBUG_LOG_PATH)
         else:
             self.show_error_popup(

--- a/source/InvoiceAppFileIO.py
+++ b/source/InvoiceAppFileIO.py
@@ -1,6 +1,6 @@
-import os
 import PyPDF2
-from typing import List
+from pathlib import Path
+from typing import Callable
 
 from source.Invoice import Invoice
 from source.constants import (
@@ -11,15 +11,6 @@ from source.constants import (
     COST_CRITERIA_PATH,
 )
 
-# TODO: Change the parsing of the config files to happen after the GUI is initialized
-#       This will allow the GUI to display an error if the config files are not found
-#       rather than crashing the program
-
-# TODO: Also make sure reset_debug_file() does not crash if the debug file does not exist
-#       which it will not right after cloning the repo
-# TODO: Don't crash the program if files are not present, in parse() functions.
-#       Seems like the file open operation is crashing it
-
 
 # InvoiceAppFileIO class to handle all file input/output operations
 class InvoiceAppFileIO:
@@ -27,10 +18,19 @@ class InvoiceAppFileIO:
     ###########################################################################
     ###                   InvoiceAppFileIO -> __init__()                    ###
     ###########################################################################
-    def __init__(self):
+    def __init__(self, report_error: Callable[[str, str], None] = lambda *_: None):
         """
         Initializes the InvoiceAppFileIO object
+
+        Args:
+            report_error (Callable[[str, str], None]): Callback used to surface a
+                file I/O failure to the user, taking an error title and message.
+                Defaults to a no-op so file I/O never depends on a reporter being
+                wired in (the controller injects the GUI's error popup)
         """
+
+        # Callback used to report file I/O failures to the user
+        self.report_error = report_error
 
         # Initialize cost criteria/exclusion lists
         self.labor_criteria = []
@@ -38,7 +38,7 @@ class InvoiceAppFileIO:
         self.shipping_criteria = []
 
     ###########################################################################
-    ###               InvoiceAppFileIO -> reset_debug_file()                ###
+    ###                InvoiceAppFileIO -> reset_debug_file()               ###
     ###########################################################################
     def reset_debug_file(self):
         """
@@ -50,31 +50,37 @@ class InvoiceAppFileIO:
         if not __debug__:
             return
 
-        # Get the log directory path and ensure the it exists
-        debug_dir = os.path.dirname(DEBUG_LOG_PATH)
-        os.makedirs(debug_dir, exist_ok=True)
+        try:
+            # Ensure the log directory exists, then delete the debug file if present
+            DEBUG_LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+            if DEBUG_LOG_PATH.is_file():
+                DEBUG_LOG_PATH.unlink()
 
-        # If the debug file inside the directory already exists, delete it
-        if os.path.isfile(DEBUG_LOG_PATH):
-            os.remove(DEBUG_LOG_PATH)
+        except OSError as error:
+            self.report_error(
+                "File Error",
+                f"Could not reset the debug log at {DEBUG_LOG_PATH}: {error}",
+            )
 
     ###########################################################################
-    ###              InvoiceAppFileIO -> reset_results_file()               ###
+    ###               InvoiceAppFileIO -> reset_results_file()             ###
     ###########################################################################
     def reset_results_file(self):
         """
         Deletes the results.txt file if it exists, to reset the results log for the next execution
         """
 
-        # Check to make sure the filepath exists
-        if not os.path.exists(os.path.dirname(DEBUG_LOG_PATH)):
-            raise FileNotFoundError(
-                f"Results file path {os.path.dirname(RESULTS_LOG_PATH)} does not exist."
-            )
+        try:
+            # Ensure the log directory exists, then delete the results file if present
+            RESULTS_LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+            if RESULTS_LOG_PATH.is_file():
+                RESULTS_LOG_PATH.unlink()
 
-        # If the file already exists, delete it
-        if os.path.isfile(RESULTS_LOG_PATH):
-            os.remove(RESULTS_LOG_PATH)
+        except OSError as error:
+            self.report_error(
+                "File Error",
+                f"Could not reset the results log at {RESULTS_LOG_PATH}: {error}",
+            )
 
     ###########################################################################
     ###              InvoiceAppFileIO -> print_to_debug_file()              ###
@@ -92,15 +98,17 @@ class InvoiceAppFileIO:
         if not __debug__:
             return
 
-        # If debug.txt already exists, append to it, otherwise write from beginning
-        if os.path.exists(os.path.dirname(DEBUG_LOG_PATH)):
-            write_or_append = "a"
-        else:
-            write_or_append = "w"
+        try:
+            # Ensure the log directory exists, then append the contents
+            DEBUG_LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+            with open(file=DEBUG_LOG_PATH, mode="a") as f:
+                f.write(contents + "\n")
 
-        # Write contents to file
-        with open(file=DEBUG_LOG_PATH, mode=write_or_append) as f:
-            f.write(contents + "\n")
+        except OSError as error:
+            self.report_error(
+                "File Error",
+                f"Could not write to the debug log at {DEBUG_LOG_PATH}: {error}",
+            )
 
     ###########################################################################
     ###         InvoiceAppFileIO -> print_invoice_to_output_file()          ###
@@ -117,50 +125,58 @@ class InvoiceAppFileIO:
                                     Defaults to False, meaning the results file will be overwritten
         """
 
-        # Check to make sure the filepath exists
-        if not os.path.exists(os.path.dirname(RESULTS_LOG_PATH)):
-            raise FileNotFoundError(
-                f"Debug file directory {os.path.dirname(RESULTS_LOG_PATH)} does not exist."
-            )
-
         # If appending output, use "a" for the file open call, otherwise use "w"
         if append_output:
             write_or_append = "a"
         else:
             write_or_append = "w"
 
-        # Write invoice contents to file
-        with open(file=RESULTS_LOG_PATH, mode=write_or_append) as f:
-            f.write(invoice.to_formatted_string())
+        try:
+            # Ensure the log directory exists, then write the invoice contents
+            RESULTS_LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+            with open(file=RESULTS_LOG_PATH, mode=write_or_append) as f:
+                f.write(invoice.to_formatted_string())
+
+        except OSError as error:
+            self.report_error(
+                "File Error",
+                f"Could not write to the results log at {RESULTS_LOG_PATH}: {error}",
+            )
 
     ###########################################################################
     ###               InvoiceAppFileIO -> read_invoice_file()               ###
     ###########################################################################
-    def read_invoice_file(self, invoice_filepath: str) -> list:
+    def read_invoice_file(self, invoice_filepath: Path) -> list:
         """
         Converts the given invoice PDF into a list of strings
         Each string in the list represents a page of the invoice PDF
 
         Args:
-            invoice_filepath (str): The file path of the invoice to read in
+            invoice_filepath (Path): The file path of the invoice to read in
 
         Returns:
-            list: A list of strings where each string is the text from a page of the invoice
+            list: A list of strings where each string is the text from a page of the
+                invoice, or an empty list if the PDF could not be read
         """
 
-        # Read text from input PDF
-        pdf = PyPDF2.PdfReader(stream=invoice_filepath)
+        try:
+            # Read text from input PDF
+            pdf = PyPDF2.PdfReader(stream=invoice_filepath)
 
-        # Create empty list
-        pages = []
+            # Extract text from each page and append to list
+            pages = []
+            for page in pdf.pages:
+                text = page.extract_text()
+                pages.append(text)
 
-        # Extract text from each page and append to list
-        for page in pdf.pages:
-            text = page.extract_text()
-            pages.append(text)
+            return pages
 
-        # Get Number of Pages
-        return pages
+        except (OSError, PyPDF2.errors.PdfReadError) as error:
+            self.report_error(
+                "File Error",
+                f"Could not read the invoice PDF at {invoice_filepath}: {error}",
+            )
+            return []
 
     ###########################################################################
     ###            InvoiceAppFileIO -> parse_sales_reps_config()            ###
@@ -171,27 +187,36 @@ class InvoiceAppFileIO:
         matching name for each sales rep as defined in the sales reps config file
 
         Returns:
-            dict: The populated dictionary with all codes as keys and names as values
+            dict: The populated dictionary with all codes as keys and names as
+                values, or an empty dictionary if the config file could not be read
         """
 
-        # Open sales rep config file for reading
-        with open(file=SALES_REPS_PATH, mode="r") as f:
-            sales_reps = {}
+        sales_reps = {}
 
-            # Search through text file, only take non-comment entries
-            for line in f:
+        try:
+            # Open sales rep config file for reading
+            with open(file=SALES_REPS_PATH, mode="r") as f:
 
-                # Strip whitespace from the line
-                line = line.strip()
+                # Search through text file, only take non-comment entries
+                for line in f:
 
-                # Skip empty lines or comment lines
-                if not line or line[0] == "*":
-                    continue
+                    # Strip whitespace from the line
+                    line = line.strip()
 
-                res = line.partition("=")
+                    # Skip empty lines or comment lines
+                    if not line or line[0] == "*":
+                        continue
 
-                # Res[0] is the sales rep code, res[2] is the sales rep name translation
-                sales_reps[res[0]] = res[2]
+                    res = line.partition("=")
+
+                    # Res[0] is the sales rep code, res[2] is the sales rep name translation
+                    sales_reps[res[0]] = res[2]
+
+        except OSError as error:
+            self.report_error(
+                "Config Error",
+                f"Could not read the sales reps config at {SALES_REPS_PATH}: {error}",
+            )
 
         return sales_reps
 
@@ -204,25 +229,34 @@ class InvoiceAppFileIO:
         payment term as defined in the payment terms config file
 
         Returns:
-            list: A list of strings, each string is a payment term that could be found in an invoice
+            list: A list of strings, each string is a payment term that could be
+                found in an invoice, or an empty list if the config could not be read
         """
 
-        # Open payment terms config file for reading
-        with open(file=PAYMENT_TERMS_PATH, mode="r") as f:
-            payment_terms = []
+        payment_terms = []
 
-            # Search through text file, only take non-comment entries
-            for line in f:
+        try:
+            # Open payment terms config file for reading
+            with open(file=PAYMENT_TERMS_PATH, mode="r") as f:
 
-                # Strip whitespace from the line
-                line = line.strip()
+                # Search through text file, only take non-comment entries
+                for line in f:
 
-                # Ignore line if empty or comment line
-                if not line or line[0] == "*":
-                    continue
+                    # Strip whitespace from the line
+                    line = line.strip()
 
-                # Append the payment term to the list
-                payment_terms.append(line)
+                    # Ignore line if empty or comment line
+                    if not line or line[0] == "*":
+                        continue
+
+                    # Append the payment term to the list
+                    payment_terms.append(line)
+
+        except OSError as error:
+            self.report_error(
+                "Config Error",
+                f"Could not read the payment terms config at {PAYMENT_TERMS_PATH}: {error}",
+            )
 
         return payment_terms
 
@@ -264,29 +298,32 @@ class InvoiceAppFileIO:
         """
         Reads all cost criteria/exclusions from the provided config file and stores them
         in member variables
-
-        Args:
-            category (str): The category of criteria being parsed
-            line (str): The current line containing the criteria/exclusion
         """
 
-        # Open payment terms config file for reading
-        with open(file=COST_CRITERIA_PATH, mode="r") as f:
+        try:
+            # Open cost criteria config file for reading
+            with open(file=COST_CRITERIA_PATH, mode="r") as f:
 
-            # Default to empty strings
-            line = ""
-            category = ""
+                # Default to empty strings
+                line = ""
+                category = ""
 
-            # Search through text file, only take non-comment entries
-            for line in f:
+                # Search through text file, only take non-comment entries
+                for line in f:
 
-                # Strip trailing whitespace from line, and skip comment lines
-                line = line.strip()
-                if not line or line[0] == "*":
-                    continue
+                    # Strip trailing whitespace from line, and skip comment lines
+                    line = line.strip()
+                    if not line or line[0] == "*":
+                        continue
 
-                if line.endswith(":"):
-                    category = line.rstrip(":").upper()
+                    if line.endswith(":"):
+                        category = line.rstrip(":").upper()
 
-                else:
-                    self.add_cost_criteria_field(category=category, line=line)
+                    else:
+                        self.add_cost_criteria_field(category=category, line=line)
+
+        except OSError as error:
+            self.report_error(
+                "Config Error",
+                f"Could not read the cost criteria config at {COST_CRITERIA_PATH}: {error}",
+            )

--- a/source/constants.py
+++ b/source/constants.py
@@ -1,19 +1,20 @@
 from decimal import Decimal
+from pathlib import Path
 
 DECIMAL_ZERO = Decimal("0.00")
 
 # Application file paths, relative to the executable's current working directory.
 
 # Base directories. The specific file paths below are composed from these.
-LOGS_DIR = "logs"
-CONFIGS_DIR = "Configs"
-INVOICES_PATH = "Invoices"
+LOGS_DIR = Path("logs")
+CONFIGS_DIR = Path("Configs")
+INVOICES_PATH = Path("Invoices")
 
 # Log files
-DEBUG_LOG_PATH = f"{LOGS_DIR}/debug.txt"
-RESULTS_LOG_PATH = f"{LOGS_DIR}/results.txt"
+DEBUG_LOG_PATH = LOGS_DIR / "debug.txt"
+RESULTS_LOG_PATH = LOGS_DIR / "results.txt"
 
 # Config files
-PAYMENT_TERMS_PATH = f"{CONFIGS_DIR}/Payment_Terms.txt"
-SALES_REPS_PATH = f"{CONFIGS_DIR}/Sales_Reps.txt"
-COST_CRITERIA_PATH = f"{CONFIGS_DIR}/Cost_Criteria.txt"
+PAYMENT_TERMS_PATH = CONFIGS_DIR / "Payment_Terms.txt"
+SALES_REPS_PATH = CONFIGS_DIR / "Sales_Reps.txt"
+COST_CRITERIA_PATH = CONFIGS_DIR / "Cost_Criteria.txt"

--- a/source/platform_utils.py
+++ b/source/platform_utils.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 # TODO: Can probably get rid of this file once I have added tkinter windows to open up, display
 #       and save files so I don't need to rely on the system text editor
-def open_in_system_editor(filepath: str):
+def open_in_system_editor(filepath: str | Path):
     # Opens a file in the OS default text editor using the absolute path to the file
     path = Path(filepath)
     if not path.is_absolute():

--- a/tests/InvoiceAppController_tests.py
+++ b/tests/InvoiceAppController_tests.py
@@ -119,6 +119,19 @@ def test_init_loads_config_files(controller):
     assert controller.controller.sales_reps == {"REP1": "Rep Name"}
 
 
+def test_init_wires_error_reporter(controller):
+    """
+    Verifies that __init__ wires the display's error popup into the file IO
+    controller as its error reporter, so file I/O failures surface to the user.
+
+    Args:
+        controller (pytest.fixture): Provides the controller and its mocks
+    """
+
+    # The file IO controller reports errors through the display's popup
+    assert controller.file_io.report_error is controller.display.show_error_popup
+
+
 ###############################################################################
 ###            Tests InvoiceAppController -> start_application()            ###
 ###############################################################################

--- a/tests/InvoiceAppDisplay_tests.py
+++ b/tests/InvoiceAppDisplay_tests.py
@@ -1,5 +1,6 @@
 import tkinter as tk
 import pytest
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch, call, MagicMock
 
@@ -8,12 +9,9 @@ from source.InvoiceAppDisplay import InvoiceAppDisplay
 from source.color_theme import DARK, LIGHT
 from source.font_settings import DEFAULT_FONT_FAMILY, DEFAULT_FONT_SIZE
 from source.constants import (
-    INVOICES_PATH,
     PAYMENT_TERMS_PATH,
     SALES_REPS_PATH,
     COST_CRITERIA_PATH,
-    RESULTS_LOG_PATH,
-    DEBUG_LOG_PATH,
 )
 
 
@@ -317,9 +315,9 @@ def test_handle_process_invoice_forwards_to_callback(mock_show_error, display):
 
     display.display.handle_process_invoice()
 
-    # The callback processes the single invoice without appending, no error shown
+    # The callback processes the single invoice without appending (as a Path), no error shown
     display.process_callback.assert_called_once_with(
-        "C:/invoices/order.pdf", append_output=False
+        Path("C:/invoices/order.pdf"), append_output=False
     )
     mock_show_error.assert_not_called()
 
@@ -327,29 +325,26 @@ def test_handle_process_invoice_forwards_to_callback(mock_show_error, display):
 ###############################################################################
 ###         Tests InvoiceAppDisplay -> handle_process_all_invoices()        ###
 ###############################################################################
-@patch("source.InvoiceAppDisplay.Path")
-def test_handle_process_all_invoices_processes_each(mock_path, display):
+@patch("source.InvoiceAppDisplay.INVOICES_PATH")
+def test_handle_process_all_invoices_processes_each(mock_invoices_path, display):
     """
     Verifies that handle_process_all_invoices iterates the invoices directory and
     forwards each file to the process callback with append_output True.
 
     Args:
-        mock_path (unittest.mock.MagicMock): Mocks the Path class
+        mock_invoices_path (unittest.mock.MagicMock): Mocks the INVOICES_PATH constant
         display (pytest.fixture): Provides the display and its mocks
     """
 
     # The invoices directory yields two invoice files
     first_invoice = MagicMock()
     second_invoice = MagicMock()
-    mock_path.return_value.resolve.return_value.iterdir.return_value = [
+    mock_invoices_path.resolve.return_value.iterdir.return_value = [
         first_invoice,
         second_invoice,
     ]
 
     display.display.handle_process_all_invoices()
-
-    # The directory is resolved from the configured invoices path
-    mock_path.assert_called_once_with(INVOICES_PATH)
 
     # Each invoice is processed in order, appending to the running output
     display.process_callback.assert_has_calls(
@@ -362,22 +357,22 @@ def test_handle_process_all_invoices_processes_each(mock_path, display):
 
 
 @patch.object(InvoiceAppDisplay, "show_error_popup")
-@patch("source.InvoiceAppDisplay.Path")
+@patch("source.InvoiceAppDisplay.INVOICES_PATH")
 def test_handle_process_all_invoices_error_shows_popup(
-    mock_path, mock_show_error, display
+    mock_invoices_path, mock_show_error, display
 ):
     """
     Verifies that handle_process_all_invoices shows an error popup when iterating
     the invoices directory raises an exception.
 
     Args:
-        mock_path (unittest.mock.MagicMock): Mocks the Path class
+        mock_invoices_path (unittest.mock.MagicMock): Mocks the INVOICES_PATH constant
         mock_show_error (unittest.mock.MagicMock): Mocks show_error_popup
         display (pytest.fixture): Provides the display and its mocks
     """
 
     # Resolving/iterating the invoices directory fails
-    mock_path.return_value.resolve.return_value.iterdir.side_effect = OSError(
+    mock_invoices_path.resolve.return_value.iterdir.side_effect = OSError(
         "directory unavailable"
     )
 
@@ -519,46 +514,47 @@ def test_handle_sales_reps_opens_config(mock_open_editor, display):
 
 
 @patch("source.InvoiceAppDisplay.open_in_system_editor")
-@patch("source.InvoiceAppDisplay.Path")
-def test_handle_results_log_opens_when_present(mock_path, mock_open_editor, display):
+@patch("source.InvoiceAppDisplay.RESULTS_LOG_PATH")
+def test_handle_results_log_opens_when_present(
+    mock_results_path, mock_open_editor, display
+):
     """
     Verifies that handle_results_log opens the results log when the file exists.
 
     Args:
-        mock_path (unittest.mock.MagicMock): Mocks the Path class
+        mock_results_path (unittest.mock.MagicMock): Mocks the RESULTS_LOG_PATH constant
         mock_open_editor (unittest.mock.MagicMock): Mocks open_in_system_editor
         display (pytest.fixture): Provides the display and its mocks
     """
 
     # The results log file exists on disk
-    mock_path.return_value.exists.return_value = True
+    mock_results_path.exists.return_value = True
 
     display.display.handle_results_log()
 
     # The existing results log is opened in the system editor
-    mock_path.assert_called_once_with(RESULTS_LOG_PATH)
-    mock_open_editor.assert_called_once_with(RESULTS_LOG_PATH)
+    mock_open_editor.assert_called_once_with(mock_results_path)
 
 
 @patch.object(InvoiceAppDisplay, "show_error_popup")
 @patch("source.InvoiceAppDisplay.open_in_system_editor")
-@patch("source.InvoiceAppDisplay.Path")
+@patch("source.InvoiceAppDisplay.RESULTS_LOG_PATH")
 def test_handle_results_log_missing_shows_error(
-    mock_path, mock_open_editor, mock_show_error, display
+    mock_results_path, mock_open_editor, mock_show_error, display
 ):
     """
     Verifies that handle_results_log shows an error popup (and opens nothing) when
     the results log file does not exist yet.
 
     Args:
-        mock_path (unittest.mock.MagicMock): Mocks the Path class
+        mock_results_path (unittest.mock.MagicMock): Mocks the RESULTS_LOG_PATH constant
         mock_open_editor (unittest.mock.MagicMock): Mocks open_in_system_editor
         mock_show_error (unittest.mock.MagicMock): Mocks show_error_popup
         display (pytest.fixture): Provides the display and its mocks
     """
 
     # The results log file has not been created
-    mock_path.return_value.exists.return_value = False
+    mock_results_path.exists.return_value = False
 
     display.display.handle_results_log()
 
@@ -568,46 +564,47 @@ def test_handle_results_log_missing_shows_error(
 
 
 @patch("source.InvoiceAppDisplay.open_in_system_editor")
-@patch("source.InvoiceAppDisplay.Path")
-def test_handle_debug_log_opens_when_present(mock_path, mock_open_editor, display):
+@patch("source.InvoiceAppDisplay.DEBUG_LOG_PATH")
+def test_handle_debug_log_opens_when_present(
+    mock_debug_path, mock_open_editor, display
+):
     """
     Verifies that handle_debug_log opens the debug log when the file exists.
 
     Args:
-        mock_path (unittest.mock.MagicMock): Mocks the Path class
+        mock_debug_path (unittest.mock.MagicMock): Mocks the DEBUG_LOG_PATH constant
         mock_open_editor (unittest.mock.MagicMock): Mocks open_in_system_editor
         display (pytest.fixture): Provides the display and its mocks
     """
 
     # The debug log file exists on disk
-    mock_path.return_value.exists.return_value = True
+    mock_debug_path.exists.return_value = True
 
     display.display.handle_debug_log()
 
     # The existing debug log is opened in the system editor
-    mock_path.assert_called_once_with(DEBUG_LOG_PATH)
-    mock_open_editor.assert_called_once_with(DEBUG_LOG_PATH)
+    mock_open_editor.assert_called_once_with(mock_debug_path)
 
 
 @patch.object(InvoiceAppDisplay, "show_error_popup")
 @patch("source.InvoiceAppDisplay.open_in_system_editor")
-@patch("source.InvoiceAppDisplay.Path")
+@patch("source.InvoiceAppDisplay.DEBUG_LOG_PATH")
 def test_handle_debug_log_missing_shows_error(
-    mock_path, mock_open_editor, mock_show_error, display
+    mock_debug_path, mock_open_editor, mock_show_error, display
 ):
     """
     Verifies that handle_debug_log shows an error popup (and opens nothing) when
     the debug log file does not exist yet.
 
     Args:
-        mock_path (unittest.mock.MagicMock): Mocks the Path class
+        mock_debug_path (unittest.mock.MagicMock): Mocks the DEBUG_LOG_PATH constant
         mock_open_editor (unittest.mock.MagicMock): Mocks open_in_system_editor
         mock_show_error (unittest.mock.MagicMock): Mocks show_error_popup
         display (pytest.fixture): Provides the display and its mocks
     """
 
     # The debug log file has not been created
-    mock_path.return_value.exists.return_value = False
+    mock_debug_path.exists.return_value = False
 
     display.display.handle_debug_log()
 

--- a/tests/InvoiceAppFileIO_tests.py
+++ b/tests/InvoiceAppFileIO_tests.py
@@ -1,13 +1,12 @@
 import pytest
+from pathlib import Path
 from unittest.mock import patch, mock_open, call, MagicMock
 
 from source.Invoice import Invoice
 from source.InvoiceAppFileIO import *
 from source.constants import (
-    DEBUG_LOG_PATH,
-    RESULTS_LOG_PATH,
-    PAYMENT_TERMS_PATH,
     SALES_REPS_PATH,
+    PAYMENT_TERMS_PATH,
     COST_CRITERIA_PATH,
 )
 
@@ -19,225 +18,199 @@ from source.constants import (
 def file_io():
     """
     Test fixture to set up an InvoiceAppFileIO object for testing to maximize
-    code reuse
+    code reuse. The error reporter is a mock so failure paths can assert that the
+    failure was surfaced to the user.
     """
 
-    return InvoiceAppFileIO()
+    return InvoiceAppFileIO(report_error=MagicMock())
 
 
-@patch("os.remove")
-@patch("os.path.isfile", return_value=True)
-@patch("os.path.dirname", return_value="debug.txt")
-@patch("os.path.exists", return_value=True)
-def test_reset_debug_file_file_exists(
-    _mock_os_exists, _mock_os_dirname, _mock_os_isfile, mock_os_remove, file_io
-):
+###############################################################################
+###              Tests InvoiceAppFileIO -> reset_debug_file()               ###
+###############################################################################
+@patch("source.InvoiceAppFileIO.DEBUG_LOG_PATH")
+def test_reset_debug_file_file_exists(mock_debug_path, file_io):
     """
-    Tests that the function reset_debug_file() will delete the debug log file if it exists
+    Tests that reset_debug_file() ensures the log directory exists and deletes the
+    debug log file when it is present.
 
     Args:
-        _mock_os_exists (unittest.mock.MagicMock): mock os.path.exists to return false
-        _mock_os_dirname (unittest.mock.MagicMock): mock os.path.dirname to return the filename
-        _mock_os_isfile (unittest.mock.MagicMock): mock os.path.isfile to return true
-        mock_os_remove (unittest.mock.MagicMock): mock os.remove to check the call count
+        mock_debug_path (unittest.mock.MagicMock): Mocks the DEBUG_LOG_PATH constant
         file_io (pytest.fixture): Test fixture to create the InvoiceAppFileIO object
     """
 
-    # Call reset_debug_file(), expecting os.remove() to be called once
+    # The debug file exists on disk
+    mock_debug_path.is_file.return_value = True
+
     file_io.reset_debug_file()
-    mock_os_remove.assert_called_once_with(DEBUG_LOG_PATH)
+
+    # The log directory is ensured and the existing debug file is deleted
+    mock_debug_path.parent.mkdir.assert_called_once_with(parents=True, exist_ok=True)
+    mock_debug_path.unlink.assert_called_once_with()
 
 
-@patch("os.remove")
-@patch("os.path.isfile", return_value=False)
-@patch("os.path.dirname", return_value="debug.txt")
-@patch("os.path.exists", return_value=True)
-def test_reset_debug_file_file_doesnt_exist(
-    _mock_os_exists, _mock_os_dirname, _mock_os_isfile, mock_os_remove, file_io
-):
+@patch("source.InvoiceAppFileIO.DEBUG_LOG_PATH")
+def test_reset_debug_file_file_doesnt_exist(mock_debug_path, file_io):
     """
-    Tests that the function reset_debug_file() will not call os.remove() to delete
-    the debug log file if it does not exist
+    Tests that reset_debug_file() does not delete the debug log file when it does
+    not exist, while still ensuring the log directory exists.
 
     Args:
-        _mock_os_exists (unittest.mock.MagicMock): mock os.path.exists to return false
-        _mock_os_dirname (unittest.mock.MagicMock): mock os.path.dirname to return the filename
-        _mock_os_isfile (unittest.mock.MagicMock): mock os.path.isfile to return true
-        mock_os_remove (unittest.mock.MagicMock): mock os.remove to check the call count
+        mock_debug_path (unittest.mock.MagicMock): Mocks the DEBUG_LOG_PATH constant
         file_io (pytest.fixture): Test fixture to create the InvoiceAppFileIO object
     """
 
-    # Call reset_debug_file(), expecting os.remove() to not be called since the
-    # file doesn't exist
+    # The debug file does not exist on disk
+    mock_debug_path.is_file.return_value = False
+
     file_io.reset_debug_file()
-    mock_os_remove.assert_not_called()
+
+    # The directory is ensured but nothing is deleted
+    mock_debug_path.parent.mkdir.assert_called_once_with(parents=True, exist_ok=True)
+    mock_debug_path.unlink.assert_not_called()
+
+
+@patch("source.InvoiceAppFileIO.DEBUG_LOG_PATH")
+def test_reset_debug_file_reports_on_error(mock_debug_path, file_io):
+    """
+    Tests that reset_debug_file() fails gracefully, surfacing the failure through
+    the error reporter instead of raising when the filesystem operation fails.
+
+    Args:
+        mock_debug_path (unittest.mock.MagicMock): Mocks the DEBUG_LOG_PATH constant
+        file_io (pytest.fixture): Test fixture to create the InvoiceAppFileIO object
+    """
+
+    # Creating the log directory fails
+    mock_debug_path.parent.mkdir.side_effect = OSError("permission denied")
+
+    # No exception is raised, and the failure is reported to the user
+    file_io.reset_debug_file()
+    file_io.report_error.assert_called_once()
 
 
 ###############################################################################
 ###              Tests InvoiceAppFileIO -> reset_results_file()             ###
 ###############################################################################
-@patch("os.path.dirname", return_value="results.txt")
-@patch("os.path.exists", return_value=False)
-def test_reset_results_file_path_doesnt_exist(
-    _mock_os_exists, _mock_os_dirname, file_io
-):
+@patch("source.InvoiceAppFileIO.RESULTS_LOG_PATH")
+def test_reset_results_file_file_exists(mock_results_path, file_io):
     """
-    Tests that the function reset_results_file() will raise an exception if
-    the results.txt file path does not exist where the InvoiceAppFileIO object
-    is told that it will
+    Tests that reset_results_file() ensures the log directory exists and deletes
+    the results log file when it is present.
 
     Args:
-        _mock_os_exists (unittest.mock.MagicMock): mock os.path.exists to return false
-        _mock_os_dirname (unittest.mock.MagicMock): mock os.path.dirname to return the filename
+        mock_results_path (unittest.mock.MagicMock): Mocks the RESULTS_LOG_PATH constant
         file_io (pytest.fixture): Test fixture to create the InvoiceAppFileIO object
     """
 
-    # Call reset_results_file(), expecting an exception to be raised
-    with pytest.raises(FileNotFoundError) as exception:
-        file_io.reset_results_file()
+    # The results file exists on disk
+    mock_results_path.is_file.return_value = True
 
-    assert "Results file path results.txt does not exist" in str(exception)
-
-
-@patch("os.remove")
-@patch("os.path.isfile", return_value=True)
-@patch("os.path.dirname", return_value="results.txt")
-@patch("os.path.exists", return_value=True)
-def test_reset_results_file_file_exists(
-    _mock_os_exists, _mock_os_dirname, _mock_os_isfile, mock_os_remove, file_io
-):
-    """
-    Tests that the function reset_results_file() will delete the results log file if it exists
-
-    Args:
-        _mock_os_exists (unittest.mock.MagicMock): mock os.path.exists to return false
-        _mock_os_dirname (unittest.mock.MagicMock): mock os.path.dirname to return the filename
-        _mock_os_isfile (unittest.mock.MagicMock): mock os.path.isfile to return true
-        mock_os_remove (unittest.mock.MagicMock): mock os.remove to check the call count
-        file_io (pytest.fixture): Test fixture to create the InvoiceAppFileIO object
-    """
-
-    # Call reset_results_file(), expecting os.remove() to be called once
     file_io.reset_results_file()
-    mock_os_remove.assert_called_once_with(RESULTS_LOG_PATH)
+
+    # The log directory is ensured and the existing results file is deleted
+    mock_results_path.parent.mkdir.assert_called_once_with(parents=True, exist_ok=True)
+    mock_results_path.unlink.assert_called_once_with()
 
 
-@patch("os.remove")
-@patch("os.path.isfile", return_value=False)
-@patch("os.path.dirname", return_value="results.txt")
-@patch("os.path.exists", return_value=True)
-def test_reset_results_file_file_doesnt_exist(
-    _mock_os_exists, _mock_os_dirname, _mock_os_isfile, mock_os_remove, file_io
-):
+@patch("source.InvoiceAppFileIO.RESULTS_LOG_PATH")
+def test_reset_results_file_file_doesnt_exist(mock_results_path, file_io):
     """
-    Tests that the function reset_results_file() will not call os.remove() to delete
-    the results log file if it does not exist
+    Tests that reset_results_file() does not delete the results log file when it
+    does not exist, while still ensuring the log directory exists.
 
     Args:
-        _mock_os_exists (unittest.mock.MagicMock): mock os.path.exists to return false
-        _mock_os_dirname (unittest.mock.MagicMock): mock os.path.dirname to return the filename
-        _mock_os_isfile (unittest.mock.MagicMock): mock os.path.isfile to return true
-        mock_os_remove (unittest.mock.MagicMock): mock os.remove to check the call count
+        mock_results_path (unittest.mock.MagicMock): Mocks the RESULTS_LOG_PATH constant
         file_io (pytest.fixture): Test fixture to create the InvoiceAppFileIO object
     """
 
-    # Call reset_results_file(), expecting os.remove() to not be called since the
-    # file doesn't exist
+    # The results file does not exist on disk
+    mock_results_path.is_file.return_value = False
+
     file_io.reset_results_file()
-    mock_os_remove.assert_not_called()
+
+    # The directory is ensured but nothing is deleted
+    mock_results_path.parent.mkdir.assert_called_once_with(parents=True, exist_ok=True)
+    mock_results_path.unlink.assert_not_called()
+
+
+@patch("source.InvoiceAppFileIO.RESULTS_LOG_PATH")
+def test_reset_results_file_reports_on_error(mock_results_path, file_io):
+    """
+    Tests that reset_results_file() fails gracefully, surfacing the failure through
+    the error reporter instead of raising when the filesystem operation fails.
+
+    Args:
+        mock_results_path (unittest.mock.MagicMock): Mocks the RESULTS_LOG_PATH constant
+        file_io (pytest.fixture): Test fixture to create the InvoiceAppFileIO object
+    """
+
+    # Deleting the existing results file fails
+    mock_results_path.is_file.return_value = True
+    mock_results_path.unlink.side_effect = OSError("file is locked")
+
+    # No exception is raised, and the failure is reported to the user
+    file_io.reset_results_file()
+    file_io.report_error.assert_called_once()
 
 
 ###############################################################################
 ###             Tests InvoiceAppFileIO -> print_to_debug_file()             ###
 ###############################################################################
 @patch("builtins.open", new_callable=mock_open)
-@patch("os.path.dirname", return_value="logs")
-@patch("os.path.exists", return_value=True)
-def test_print_to_debug_file_appends_when_dir_exists(
-    _mock_os_exists, _mock_os_dirname, mock_file, file_io
-):
+@patch("source.InvoiceAppFileIO.DEBUG_LOG_PATH")
+def test_print_to_debug_file_appends(mock_debug_path, mock_file, file_io):
     """
-    Tests that print_to_debug_file() opens the debug log in append mode and
-    writes the contents (with a trailing newline) when the log directory exists.
+    Tests that print_to_debug_file() ensures the log directory exists, opens the
+    debug log in append mode, and writes the contents with a trailing newline.
 
     Args:
-        _mock_os_exists (unittest.mock.MagicMock): mock os.path.exists to return true
-        _mock_os_dirname (unittest.mock.MagicMock): mock os.path.dirname to return the directory
+        mock_debug_path (unittest.mock.MagicMock): Mocks the DEBUG_LOG_PATH constant
         mock_file (unittest.mock.MagicMock): Mocks the built-in open()
         file_io (pytest.fixture): Test fixture to create the InvoiceAppFileIO object
     """
 
-    # Call print_to_debug_file(), expecting an append-mode open and a write
     file_io.print_to_debug_file("some debug message")
-    mock_file.assert_called_once_with(file=DEBUG_LOG_PATH, mode="a")
+
+    # The directory is ensured and the contents are appended
+    mock_debug_path.parent.mkdir.assert_called_once_with(parents=True, exist_ok=True)
+    mock_file.assert_called_once_with(file=mock_debug_path, mode="a")
     mock_file().write.assert_called_once_with("some debug message\n")
 
 
-@patch("builtins.open", new_callable=mock_open)
-@patch("os.path.dirname", return_value="logs")
-@patch("os.path.exists", return_value=False)
-def test_print_to_debug_file_writes_when_dir_doesnt_exist(
-    _mock_os_exists, _mock_os_dirname, mock_file, file_io
-):
+@patch("builtins.open", side_effect=OSError("disk full"))
+@patch("source.InvoiceAppFileIO.DEBUG_LOG_PATH")
+def test_print_to_debug_file_reports_on_error(mock_debug_path, _mock_file, file_io):
     """
-    Tests that print_to_debug_file() opens the debug log in write mode and
-    writes the contents (with a trailing newline) when the log directory does
-    not yet exist.
+    Tests that print_to_debug_file() fails gracefully, surfacing the failure
+    through the error reporter instead of raising when the write fails.
 
     Args:
-        _mock_os_exists (unittest.mock.MagicMock): mock os.path.exists to return false
-        _mock_os_dirname (unittest.mock.MagicMock): mock os.path.dirname to return the directory
-        mock_file (unittest.mock.MagicMock): Mocks the built-in open()
+        mock_debug_path (unittest.mock.MagicMock): Mocks the DEBUG_LOG_PATH constant
+        _mock_file (unittest.mock.MagicMock): Mocks the built-in open() to raise
         file_io (pytest.fixture): Test fixture to create the InvoiceAppFileIO object
     """
 
-    # Call print_to_debug_file(), expecting a write-mode open and a write
+    # No exception is raised, and the failure is reported to the user
     file_io.print_to_debug_file("some debug message")
-    mock_file.assert_called_once_with(file=DEBUG_LOG_PATH, mode="w")
-    mock_file().write.assert_called_once_with("some debug message\n")
+    file_io.report_error.assert_called_once()
 
 
 ###############################################################################
 ###        Tests InvoiceAppFileIO -> print_invoice_to_output_file()         ###
 ###############################################################################
-@patch("os.path.dirname", return_value="logs")
-@patch("os.path.exists", return_value=False)
-def test_print_invoice_to_output_file_path_doesnt_exist(
-    _mock_os_exists, _mock_os_dirname, file_io
-):
-    """
-    Tests that print_invoice_to_output_file() raises a FileNotFoundError when
-    the results log directory does not exist.
-
-    Args:
-        _mock_os_exists (unittest.mock.MagicMock): mock os.path.exists to return false
-        _mock_os_dirname (unittest.mock.MagicMock): mock os.path.dirname to return the directory
-        file_io (pytest.fixture): Test fixture to create the InvoiceAppFileIO object
-    """
-
-    # A mock invoice is sufficient; the directory check fails before it is used
-    mock_invoice = MagicMock(spec=Invoice)
-
-    # Call print_invoice_to_output_file(), expecting an exception to be raised
-    with pytest.raises(FileNotFoundError) as exception:
-        file_io.print_invoice_to_output_file(mock_invoice)
-
-    assert "Debug file directory logs does not exist" in str(exception)
-
-
 @patch("builtins.open", new_callable=mock_open)
-@patch("os.path.dirname", return_value="logs")
-@patch("os.path.exists", return_value=True)
+@patch("source.InvoiceAppFileIO.RESULTS_LOG_PATH")
 def test_print_invoice_to_output_file_overwrites_by_default(
-    _mock_os_exists, _mock_os_dirname, mock_file, file_io
+    mock_results_path, mock_file, file_io
 ):
     """
-    Tests that print_invoice_to_output_file() opens the results log in write
-    mode (overwriting) by default and writes the invoice's formatted string.
+    Tests that print_invoice_to_output_file() ensures the log directory exists,
+    opens the results log in write mode (overwriting) by default, and writes the
+    invoice's formatted string.
 
     Args:
-        _mock_os_exists (unittest.mock.MagicMock): mock os.path.exists to return true
-        _mock_os_dirname (unittest.mock.MagicMock): mock os.path.dirname to return the directory
+        mock_results_path (unittest.mock.MagicMock): Mocks the RESULTS_LOG_PATH constant
         mock_file (unittest.mock.MagicMock): Mocks the built-in open()
         file_io (pytest.fixture): Test fixture to create the InvoiceAppFileIO object
     """
@@ -246,25 +219,25 @@ def test_print_invoice_to_output_file_overwrites_by_default(
     mock_invoice = MagicMock(spec=Invoice)
     mock_invoice.to_formatted_string.return_value = "formatted invoice"
 
-    # Call print_invoice_to_output_file(), expecting a write-mode open and a write
     file_io.print_invoice_to_output_file(mock_invoice)
-    mock_file.assert_called_once_with(file=RESULTS_LOG_PATH, mode="w")
+
+    # The directory is ensured and the invoice is written in overwrite mode
+    mock_results_path.parent.mkdir.assert_called_once_with(parents=True, exist_ok=True)
+    mock_file.assert_called_once_with(file=mock_results_path, mode="w")
     mock_file().write.assert_called_once_with("formatted invoice")
 
 
 @patch("builtins.open", new_callable=mock_open)
-@patch("os.path.dirname", return_value="logs")
-@patch("os.path.exists", return_value=True)
+@patch("source.InvoiceAppFileIO.RESULTS_LOG_PATH")
 def test_print_invoice_to_output_file_appends_when_requested(
-    _mock_os_exists, _mock_os_dirname, mock_file, file_io
+    mock_results_path, mock_file, file_io
 ):
     """
-    Tests that print_invoice_to_output_file() opens the results log in append
-    mode when append_output is True and writes the invoice's formatted string.
+    Tests that print_invoice_to_output_file() opens the results log in append mode
+    when append_output is True and writes the invoice's formatted string.
 
     Args:
-        _mock_os_exists (unittest.mock.MagicMock): mock os.path.exists to return true
-        _mock_os_dirname (unittest.mock.MagicMock): mock os.path.dirname to return the directory
+        mock_results_path (unittest.mock.MagicMock): Mocks the RESULTS_LOG_PATH constant
         mock_file (unittest.mock.MagicMock): Mocks the built-in open()
         file_io (pytest.fixture): Test fixture to create the InvoiceAppFileIO object
     """
@@ -273,19 +246,82 @@ def test_print_invoice_to_output_file_appends_when_requested(
     mock_invoice = MagicMock(spec=Invoice)
     mock_invoice.to_formatted_string.return_value = "formatted invoice"
 
-    # Call with append_output=True, expecting an append-mode open and a write
     file_io.print_invoice_to_output_file(mock_invoice, append_output=True)
-    mock_file.assert_called_once_with(file=RESULTS_LOG_PATH, mode="a")
+
+    # The invoice is written in append mode
+    mock_file.assert_called_once_with(file=mock_results_path, mode="a")
     mock_file().write.assert_called_once_with("formatted invoice")
+
+
+@patch("builtins.open", side_effect=OSError("disk full"))
+@patch("source.InvoiceAppFileIO.RESULTS_LOG_PATH")
+def test_print_invoice_to_output_file_reports_on_error(
+    mock_results_path, _mock_file, file_io
+):
+    """
+    Tests that print_invoice_to_output_file() fails gracefully, surfacing the
+    failure through the error reporter instead of raising when the write fails.
+
+    Args:
+        mock_results_path (unittest.mock.MagicMock): Mocks the RESULTS_LOG_PATH constant
+        _mock_file (unittest.mock.MagicMock): Mocks the built-in open() to raise
+        file_io (pytest.fixture): Test fixture to create the InvoiceAppFileIO object
+    """
+
+    mock_invoice = MagicMock(spec=Invoice)
+
+    # No exception is raised, and the failure is reported to the user
+    file_io.print_invoice_to_output_file(mock_invoice)
+    file_io.report_error.assert_called_once()
 
 
 ###############################################################################
 ###              Tests InvoiceAppFileIO -> read_invoice_file()              ###
 ###############################################################################
+@patch("source.InvoiceAppFileIO.PyPDF2.PdfReader")
+def test_read_invoice_file_extracts_each_page(mock_reader, file_io):
+    """
+    Tests that read_invoice_file() returns the extracted text of each page in the
+    PDF, in order.
 
-"""
-Opting to not write unit tests for this function since PyPDF2 will be replaced soon
-"""
+    Args:
+        mock_reader (unittest.mock.MagicMock): Mocks PyPDF2.PdfReader
+        file_io (pytest.fixture): Test fixture to create the InvoiceAppFileIO object
+    """
+
+    # The PDF reader yields two pages with known text
+    first_page = MagicMock()
+    first_page.extract_text.return_value = "page one"
+    second_page = MagicMock()
+    second_page.extract_text.return_value = "page two"
+    mock_reader.return_value.pages = [first_page, second_page]
+
+    pages = file_io.read_invoice_file(Path("invoice.pdf"))
+
+    # The reader is given the invoice path and each page's text is returned in order
+    mock_reader.assert_called_once_with(stream=Path("invoice.pdf"))
+    assert pages == ["page one", "page two"]
+
+
+@patch(
+    "source.InvoiceAppFileIO.PyPDF2.PdfReader",
+    side_effect=OSError("file not found"),
+)
+def test_read_invoice_file_reports_and_returns_empty_on_error(mock_reader, file_io):
+    """
+    Tests that read_invoice_file() fails gracefully, surfacing the failure through
+    the error reporter and returning an empty list when the PDF cannot be read.
+
+    Args:
+        mock_reader (unittest.mock.MagicMock): Mocks PyPDF2.PdfReader to raise
+        file_io (pytest.fixture): Test fixture to create the InvoiceAppFileIO object
+    """
+
+    pages = file_io.read_invoice_file(Path("missing.pdf"))
+
+    # No exception is raised, an empty list is returned, and the failure is reported
+    assert pages == []
+    file_io.report_error.assert_called_once()
 
 
 ###############################################################################
@@ -352,6 +388,25 @@ def test_parse_sales_reps_config_empty_file(mock_file, file_io):
     mock_file.assert_called_once_with(file=SALES_REPS_PATH, mode="r")
 
 
+@patch("builtins.open", side_effect=OSError("file not found"))
+def test_parse_sales_reps_config_reports_on_error(_mock_file, file_io):
+    """
+    Tests that parse_sales_reps_config() fails gracefully, surfacing the failure
+    through the error reporter and returning an empty dictionary when the config
+    file cannot be read.
+
+    Args:
+        _mock_file (unittest.mock.MagicMock): Mocks the built-in open() to raise
+        file_io (pytest.fixture): Test fixture for InvoiceAppFileIO
+    """
+
+    sales_reps = file_io.parse_sales_reps_config()
+
+    # An empty dictionary is returned and the failure is reported to the user
+    assert sales_reps == {}
+    file_io.report_error.assert_called_once()
+
+
 ###############################################################################
 ###        Tests InvoiceAppFileIO -> parse_payment_terms_config()           ###
 ###############################################################################
@@ -414,6 +469,25 @@ def test_parse_payment_terms_config_empty_file(mock_file, file_io):
 
     # Ensure the file was opened in reading mode
     mock_file.assert_called_once_with(file=PAYMENT_TERMS_PATH, mode="r")
+
+
+@patch("builtins.open", side_effect=OSError("file not found"))
+def test_parse_payment_terms_config_reports_on_error(_mock_file, file_io):
+    """
+    Tests that parse_payment_terms_config() fails gracefully, surfacing the failure
+    through the error reporter and returning an empty list when the config file
+    cannot be read.
+
+    Args:
+        _mock_file (unittest.mock.MagicMock): Mocks the built-in open() to raise
+        file_io (pytest.fixture): Test fixture for InvoiceAppFileIO
+    """
+
+    payment_terms = file_io.parse_payment_terms_config()
+
+    # An empty list is returned and the failure is reported to the user
+    assert payment_terms == []
+    file_io.report_error.assert_called_once()
 
 
 ###############################################################################
@@ -515,3 +589,20 @@ def test_parse_cost_criteria_file_calls_add_cost_criteria_field(
 
     # Verify file was opened for reading
     mock_file.assert_called_once_with(file=COST_CRITERIA_PATH, mode="r")
+
+
+@patch("builtins.open", side_effect=OSError("file not found"))
+def test_parse_cost_criteria_file_reports_on_error(_mock_file, file_io):
+    """
+    Tests that parse_cost_criteria_file() fails gracefully, surfacing the failure
+    through the error reporter instead of raising when the config file cannot be
+    read.
+
+    Args:
+        _mock_file (unittest.mock.MagicMock): Mocks the built-in open() to raise
+        file_io (pytest.fixture): Test fixture for InvoiceAppFileIO
+    """
+
+    # No exception is raised, and the failure is reported to the user
+    file_io.parse_cost_criteria_file()
+    file_io.report_error.assert_called_once()


### PR DESCRIPTION
## Summary

Resolves #35 — adopt the Python-standard `pathlib.Path` consistently across every component that handles file paths, and make all file I/O fail gracefully (never throw) instead of crashing on a missing `Configs/`, `logs/`, or `Invoices/` path.

## Path modernization
- **`source/constants.py`** — path constants are now `Path` objects composed with `/` (single source of truth).
- **`source/InvoiceAppFileIO.py`** — dropped `os` in favor of `Path` methods (`.parent.mkdir`, `.is_file()`, `.unlink()`); reads/writes still use the builtin `open()`, which accepts `Path`.
- **`source/InvoiceAppDisplay.py`** — `str(INVOICES_PATH)` for the Tk dialog, wraps the chosen file in `Path()`, and calls `.exists()` / `.resolve().iterdir()` directly on the `Path` constants.
- **`source/platform_utils.py`** / **controller** — widened/updated type hints to `Path`.

## Graceful failure
- Every filesystem-touching method in `InvoiceAppFileIO` is wrapped in `try/except`, returns a safe default (`{}`, `[]`, `None`, or no-op), and surfaces the failure through an **injected `report_error` callback** instead of raising. The two methods that previously raised `FileNotFoundError` now ensure the directory exists (`mkdir(parents=True, exist_ok=True)`) and report on any residual error.
- To keep file I/O decoupled from tkinter (per the SRP/ISP rules in `CLAUDE.md`), the callback is injected — the controller wires `display.show_error_popup` in, mirroring the existing `process_callback` pattern.
- Fixed a latent missing `f`-prefix bug on the no-pages popup message in the controller.

## Testing
- **96/96 unit tests pass**; total coverage **98%** (`InvoiceAppFileIO` is 100%), above the 90% gate. Rewrote the FileIO tests for the `Path`/graceful-failure behavior, repointed the display tests to patch the `Path` constants, and added a controller test for reporter wiring.
- **Integration test passes** — `python main.py --integration-test` output is byte-identical to `canonical_correct_results.txt`.
- **Graceful-failure check** — missing PDFs/configs return safe defaults, raise nothing, and fire the reporter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)