### PR TITLE
Persist user settings (theme/font) in SQLite (closes #29)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ Invoices/*
 
 # Ignore config files
 Configs/*
+
+# Ignore the per-machine user settings database
+data/

--- a/source/InvoiceAppController.py
+++ b/source/InvoiceAppController.py
@@ -5,6 +5,7 @@ from source.InvoiceAppDisplay import InvoiceAppDisplay
 from source.InvoiceAppFileIO import InvoiceAppFileIO
 from source.InvoiceProcessor import InvoiceProcessor
 from source.ArgumentProvider import ArgumentProvider
+from source.SettingsRepository import SettingsRepository
 from source.Invoice import Invoice
 from source.constants import (
     COST_CRITERIA_PATH,
@@ -45,21 +46,31 @@ class InvoiceAppController:
             shipping_criteria=self.file_io_controller.shipping_criteria,
         )
 
+        # Create the Settings Repository and load the user's persisted settings so
+        # they can be handed to the display and restored on startup.
+        self.settings_repository = SettingsRepository()
+        saved_settings = self.settings_repository.get_all_settings()
+
         # Create the InvoiceAppDisplay GUI, providing it with the callbacks it
         # needs: processing invoices, reading a file's contents for the native
-        # editor/viewer windows, and saving edited config files.
+        # editor/viewer windows, saving edited config files, and persisting user
+        # settings. The saved settings restore the user's last theme/font choices.
         self.display = InvoiceAppDisplay(
             title="Invoice Processor",
             window_resolution="750x750",
             process_callback=self.handle_process_invoice,
             read_file_callback=self.file_io_controller.read_text_file,
             save_config_callback=self.handle_save_config,
+            save_settings_callback=self.handle_save_setting,
+            settings=saved_settings,
         )
 
-        # Wire the GUI's error popup into the File IO Controller so file I/O failures
-        # surface to the user without coupling file I/O to the GUI. This must happen
-        # before the config files are parsed below so parse failures can be reported.
+        # Wire the GUI's error popup into the File IO Controller and Settings
+        # Repository so file/database failures surface to the user without coupling
+        # those components to the GUI. This must happen before the config files are
+        # parsed below so parse failures can be reported.
         self.file_io_controller.report_error = self.display.show_error_popup
+        self.settings_repository.report_error = self.display.show_error_popup
 
         # Use the File IO Controller to read in the criteria/exclusions for each cost section
         self.file_io_controller.parse_cost_criteria_file()
@@ -193,6 +204,20 @@ class InvoiceAppController:
         reloader = reloaders.get(config_path)
         if reloader:
             reloader()
+
+    ###########################################################################
+    ###            InvoiceAppController -> handle_save_setting()            ###
+    ###########################################################################
+    def handle_save_setting(self, key: str, value: str):
+        """
+        Persists a single user setting so it is restored on the next launch.
+
+        Args:
+            key (str): The setting's identifier (e.g. "theme", "font_family")
+            value (str): The setting's value to store
+        """
+
+        self.settings_repository.save_setting(key=key, value=value)
 
     ###########################################################################
     ###           InvoiceAppController -> _reload_cost_criteria()           ###

--- a/source/InvoiceAppDisplay.py
+++ b/source/InvoiceAppDisplay.py
@@ -8,8 +8,8 @@ from source.ArgumentProvider import ArgumentProvider
 from source.FileEditorWindow import FileEditorWindow
 from source.color_theme import (
     ALL_THEMES,
-    DARK,
-    RED,
+    DARK,  # Default theme used by GUI
+    RED,  # Used for the EXIT button
     THEME_BY_NAME,
     Theme,
 )
@@ -105,9 +105,7 @@ class InvoiceAppDisplay(tk.Tk):
         # for anything missing or unrecognized. These are set before build_widgets()
         # so every widget is created already using the restored theme and font.
         settings = settings or {}
-        self.current_theme = THEME_BY_NAME.get(
-            settings.get(SETTING_KEY_THEME), DARK
-        )
+        self.current_theme = THEME_BY_NAME.get(settings.get(SETTING_KEY_THEME), DARK)
         self.current_font_family = settings.get(
             SETTING_KEY_FONT_FAMILY, DEFAULT_FONT_FAMILY
         )

--- a/source/InvoiceAppDisplay.py
+++ b/source/InvoiceAppDisplay.py
@@ -10,6 +10,7 @@ from source.color_theme import (
     ALL_THEMES,
     DARK,
     RED,
+    THEME_BY_NAME,
     Theme,
 )
 from source.font_settings import (
@@ -25,6 +26,9 @@ from source.constants import (
     COST_CRITERIA_PATH,
     RESULTS_LOG_PATH,
     DEBUG_LOG_PATH,
+    SETTING_KEY_THEME,
+    SETTING_KEY_FONT_FAMILY,
+    SETTING_KEY_FONT_SIZE,
 )
 
 # Future TODO: Add second output window for errors, instead of cluttering the screen with
@@ -43,8 +47,10 @@ class InvoiceAppDisplay(tk.Tk):
         process_callback,
         read_file_callback: Callable[[Path], str],
         save_config_callback: Callable[[Path, str], None],
+        save_settings_callback: Callable[[str, str], None],
         title: str,
         window_resolution: str,
+        settings: dict | None = None,
     ):
         """
         Initializes the InvoiceAppDisplay object
@@ -55,8 +61,14 @@ class InvoiceAppDisplay(tk.Tk):
                 full contents, used to populate the native file editor/viewer window
             save_config_callback (Callable[[Path, str], None]): Callback that persists
                 edited config contents (and reloads them), invoked when the user saves
+            save_settings_callback (Callable[[str, str], None]): Callback that persists
+                a single user setting (key, value), invoked when the user changes a
+                theme/font/font-size preference
             title (str): Title of the application window
             window_resolution (str): Resolution of the application window (e.g., "750x750")
+            settings (dict | None): Previously persisted settings (theme/font/font-size)
+                used to restore the user's last choices on startup. Missing or unknown
+                values fall back to the application defaults.
         """
 
         super().__init__()
@@ -86,14 +98,22 @@ class InvoiceAppDisplay(tk.Tk):
         # Callback to persist (and reload) edited config file contents
         self.save_config_callback = save_config_callback
 
-        # Active theme, defaults to Dark
-        self.current_theme = DARK
+        # Callback to persist a single changed user setting (theme/font/size)
+        self.save_settings_callback = save_settings_callback
 
-        # Active font family, defaults to DEFAULT_FONT_FAMILY
-        self.current_font_family = DEFAULT_FONT_FAMILY
-
-        # Active font size, defaults to DEFAULT_FONT_SIZE
-        self.current_font_size = DEFAULT_FONT_SIZE
+        # Restore the user's last-chosen settings, falling back to the defaults
+        # for anything missing or unrecognized. These are set before build_widgets()
+        # so every widget is created already using the restored theme and font.
+        settings = settings or {}
+        self.current_theme = THEME_BY_NAME.get(
+            settings.get(SETTING_KEY_THEME), DARK
+        )
+        self.current_font_family = settings.get(
+            SETTING_KEY_FONT_FAMILY, DEFAULT_FONT_FAMILY
+        )
+        self.current_font_size = self._parse_font_size(
+            settings.get(SETTING_KEY_FONT_SIZE)
+        )
 
         # Tkinter Widgets
         # fmt:off
@@ -582,6 +602,9 @@ class InvoiceAppDisplay(tk.Tk):
             bg=theme.bg_entry, fg=theme.fg_text, insertbackground=theme.fg_text
         )
 
+        # Persist the choice so it is restored on the next launch
+        self.save_settings_callback(SETTING_KEY_THEME, theme.name)
+
     ###########################################################################
     ###              InvoiceAppDisplay -> apply_font_family()               ###
     ###########################################################################
@@ -595,6 +618,9 @@ class InvoiceAppDisplay(tk.Tk):
         self.current_font_family = family
         self._apply_font()
 
+        # Persist the choice so it is restored on the next launch
+        self.save_settings_callback(SETTING_KEY_FONT_FAMILY, family)
+
     ###########################################################################
     ###               InvoiceAppDisplay -> apply_font_size()                ###
     ###########################################################################
@@ -607,6 +633,31 @@ class InvoiceAppDisplay(tk.Tk):
         """
         self.current_font_size = size
         self._apply_font()
+
+        # Persist the choice so it is restored on the next launch. Settings are
+        # stored as strings, so the size is converted on the way out.
+        self.save_settings_callback(SETTING_KEY_FONT_SIZE, str(size))
+
+    ###########################################################################
+    ###               InvoiceAppDisplay -> _parse_font_size()               ###
+    ###########################################################################
+    def _parse_font_size(self, value) -> int:
+        """
+        Converts a persisted font size value into an int, falling back to the
+        default when it is missing or not a valid integer.
+
+        Args:
+            value: The raw font size loaded from settings (a string, or None when
+                no size has been persisted yet)
+
+        Returns:
+            int: The restored font size, or DEFAULT_FONT_SIZE if value is missing
+                or non-numeric.
+        """
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return DEFAULT_FONT_SIZE
 
     ###########################################################################
     ###                 InvoiceAppDisplay -> _apply_font()                  ###

--- a/source/SettingsRepository.py
+++ b/source/SettingsRepository.py
@@ -1,0 +1,107 @@
+import sqlite3
+from typing import Callable
+
+from source.constants import SETTINGS_DB_PATH
+
+
+# SettingsRepository class to persist user-controlled settings (theme, font, etc.)
+# in a SQLite database so they survive between application restarts.
+class SettingsRepository:
+
+    ###########################################################################
+    ###                  SettingsRepository -> __init__()                   ###
+    ###########################################################################
+    def __init__(self, report_error: Callable[[str, str], None] = lambda *_: None):
+        """
+        Initializes the SettingsRepository, ensuring the database file and its
+        settings table exist.
+
+        Args:
+            report_error (Callable[[str, str], None]): Callback used to surface a
+                database failure to the user, taking an error title and message.
+                Defaults to a no-op so the repository never depends on a reporter
+                being wired in (the controller injects the GUI's error popup).
+        """
+
+        # Callback used to report database failures to the user
+        self.report_error = report_error
+
+        # Create the database file and schema up front so reads/writes can assume
+        # the settings table exists.
+        self.initialize_database()
+
+    ###########################################################################
+    ###              SettingsRepository -> initialize_database()            ###
+    ###########################################################################
+    def initialize_database(self):
+        """
+        Ensures the data directory, database file, and settings table exist.
+
+        The settings table is a generic key/value store so new settings can be
+        added without changing the schema.
+        """
+
+        try:
+            # Ensure the data directory exists before SQLite creates the file
+            SETTINGS_DB_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+            with sqlite3.connect(SETTINGS_DB_PATH) as connection:
+                connection.execute(
+                    "CREATE TABLE IF NOT EXISTS settings ("
+                    "key TEXT PRIMARY KEY, "
+                    "value TEXT)"
+                )
+        except sqlite3.Error as error:
+            self.report_error(
+                "Settings Error",
+                f"Could not initialize the settings database at {SETTINGS_DB_PATH}: {error}",
+            )
+
+    ###########################################################################
+    ###               SettingsRepository -> get_all_settings()             ###
+    ###########################################################################
+    def get_all_settings(self) -> dict:
+        """
+        Reads every persisted setting from the database.
+
+        Returns:
+            dict: A mapping of each setting key to its stored string value. Empty
+                if the database is fresh or could not be read.
+        """
+
+        try:
+            with sqlite3.connect(SETTINGS_DB_PATH) as connection:
+                rows = connection.execute("SELECT key, value FROM settings").fetchall()
+                return {key: value for key, value in rows}
+        except sqlite3.Error as error:
+            self.report_error(
+                "Settings Error",
+                f"Could not read settings from the database at {SETTINGS_DB_PATH}: {error}",
+            )
+            return {}
+
+    ###########################################################################
+    ###                 SettingsRepository -> save_setting()                ###
+    ###########################################################################
+    def save_setting(self, key: str, value: str):
+        """
+        Persists a single setting, inserting it or updating it if the key already
+        exists.
+
+        Args:
+            key (str): The setting's identifier (e.g. "theme", "font_family").
+            value (str): The setting's value to store.
+        """
+
+        try:
+            with sqlite3.connect(SETTINGS_DB_PATH) as connection:
+                connection.execute(
+                    "INSERT INTO settings (key, value) VALUES (?, ?) "
+                    "ON CONFLICT(key) DO UPDATE SET value=excluded.value",
+                    (key, value),
+                )
+        except sqlite3.Error as error:
+            self.report_error(
+                "Settings Error",
+                f"Could not save the setting '{key}' to the database at {SETTINGS_DB_PATH}: {error}",
+            )

--- a/source/color_theme.py
+++ b/source/color_theme.py
@@ -134,3 +134,8 @@ FOREST = Theme(
 
 # Provide a list of all themes that are available for use
 ALL_THEMES = [DARK, LIGHT, OCEAN, FOREST]
+
+# Map each theme's name to its Theme so a persisted theme name can be resolved
+# back to a Theme on startup. Built from ALL_THEMES so new themes are included
+# automatically without touching the lookup.
+THEME_BY_NAME = {theme.name: theme for theme in ALL_THEMES}

--- a/source/constants.py
+++ b/source/constants.py
@@ -9,6 +9,7 @@ DECIMAL_ZERO = Decimal("0.00")
 LOGS_DIR = Path("logs")
 CONFIGS_DIR = Path("Configs")
 INVOICES_PATH = Path("Invoices")
+DATA_DIR = Path("data")
 
 # Log files
 DEBUG_LOG_PATH = LOGS_DIR / "debug.txt"
@@ -18,3 +19,13 @@ RESULTS_LOG_PATH = LOGS_DIR / "results.txt"
 PAYMENT_TERMS_PATH = CONFIGS_DIR / "Payment_Terms.txt"
 SALES_REPS_PATH = CONFIGS_DIR / "Sales_Reps.txt"
 COST_CRITERIA_PATH = CONFIGS_DIR / "Cost_Criteria.txt"
+
+# Database file holding persisted user settings (theme, font, etc.)
+SETTINGS_DB_PATH = DATA_DIR / "settings.db"
+
+# Keys under which user settings are persisted in the settings database. Shared
+# between the display (which reads/writes them) and any other consumer so the
+# two never drift apart.
+SETTING_KEY_THEME = "theme"
+SETTING_KEY_FONT_FAMILY = "font_family"
+SETTING_KEY_FONT_SIZE = "font_size"

--- a/tests/InvoiceAppController_tests.py
+++ b/tests/InvoiceAppController_tests.py
@@ -34,6 +34,7 @@ def controller():
         patch("source.InvoiceAppController.InvoiceAppFileIO") as mock_file_io_cls,
         patch("source.InvoiceAppController.InvoiceProcessor") as mock_processor_cls,
         patch("source.InvoiceAppController.InvoiceAppDisplay") as mock_display_cls,
+        patch("source.InvoiceAppController.SettingsRepository") as mock_settings_repo_cls,
         patch("source.InvoiceAppController.Invoice") as mock_invoice_cls,
     ):
 
@@ -42,6 +43,7 @@ def controller():
         mock_file_io = mock_file_io_cls.return_value
         mock_processor = mock_processor_cls.return_value
         mock_display = mock_display_cls.return_value
+        mock_settings_repo = mock_settings_repo_cls.return_value
 
         # Provide the criteria attributes the controller reads off file_io while
         # wiring up the InvoiceProcessor during construction
@@ -52,6 +54,9 @@ def controller():
         # Config parsing return values the controller stores during construction
         mock_file_io.parse_payment_terms_config.return_value = ["Net 30"]
         mock_file_io.parse_sales_reps_config.return_value = {"REP1": "Rep Name"}
+
+        # Persisted settings the controller loads and hands to the display
+        mock_settings_repo.get_all_settings.return_value = {"theme": "Ocean"}
 
         # Default to GUI (non integration-test) mode
         mock_arg_provider.integration_test_mode = False
@@ -68,6 +73,8 @@ def controller():
             processor=mock_processor,
             display_cls=mock_display_cls,
             display=mock_display,
+            settings_repo_cls=mock_settings_repo_cls,
+            settings_repo=mock_settings_repo,
             invoice_cls=mock_invoice_cls,
             invoice=mock_invoice_cls.return_value,
         )
@@ -99,13 +106,16 @@ def test_init_constructs_and_wires_collaborators(controller):
     )
 
     # The display is wired with the controller's process callback, the file IO
-    # controller's text-file reader, and the controller's config save handler
+    # controller's text-file reader, the controller's config save handler, the
+    # controller's settings save handler, and the persisted settings to restore
     controller.display_cls.assert_called_once_with(
         title="Invoice Processor",
         window_resolution="750x750",
         process_callback=controller.controller.handle_process_invoice,
         read_file_callback=controller.file_io.read_text_file,
         save_config_callback=controller.controller.handle_save_config,
+        save_settings_callback=controller.controller.handle_save_setting,
+        settings={"theme": "Ocean"},
     )
 
 
@@ -131,14 +141,30 @@ def test_init_loads_config_files(controller):
 def test_init_wires_error_reporter(controller):
     """
     Verifies that __init__ wires the display's error popup into the file IO
-    controller as its error reporter, so file I/O failures surface to the user.
+    controller and settings repository as their error reporter, so file/database
+    failures surface to the user.
 
     Args:
         controller (pytest.fixture): Provides the controller and its mocks
     """
 
-    # The file IO controller reports errors through the display's popup
+    # The file IO controller and settings repository report errors through the popup
     assert controller.file_io.report_error is controller.display.show_error_popup
+    assert controller.settings_repo.report_error is controller.display.show_error_popup
+
+
+def test_init_loads_persisted_settings(controller):
+    """
+    Verifies that __init__ reads the persisted settings from the settings
+    repository so they can be handed to the display for restoration.
+
+    Args:
+        controller (pytest.fixture): Provides the controller and its mocks
+    """
+
+    # The settings repository is constructed and queried for the saved settings
+    controller.settings_repo_cls.assert_called_once_with()
+    controller.settings_repo.get_all_settings.assert_called_once_with()
 
 
 ###############################################################################
@@ -389,3 +415,23 @@ def test_handle_save_config_unknown_path_writes_without_reparsing(controller):
     controller.file_io.parse_cost_criteria_file.assert_not_called()
     controller.file_io.parse_payment_terms_config.assert_not_called()
     controller.file_io.parse_sales_reps_config.assert_not_called()
+
+
+###############################################################################
+###            Tests InvoiceAppController -> handle_save_setting()          ###
+###############################################################################
+def test_handle_save_setting_delegates_to_repository(controller):
+    """
+    Verifies that handle_save_setting forwards the key/value to the settings
+    repository to be persisted.
+
+    Args:
+        controller (pytest.fixture): Provides the controller and its mocks
+    """
+
+    controller.controller.handle_save_setting("theme", "Forest")
+
+    # The setting is persisted through the settings repository
+    controller.settings_repo.save_setting.assert_called_once_with(
+        key="theme", value="Forest"
+    )

--- a/tests/InvoiceAppDisplay_tests.py
+++ b/tests/InvoiceAppDisplay_tests.py
@@ -33,7 +33,7 @@ def _distinct_widget(*_args, **_kwargs):
 ###                   InvoiceAppDisplay -> Test Fixture                     ###
 ###############################################################################
 @pytest.fixture
-def display():
+def display(request):
     """
     Builds an InvoiceAppDisplay in complete isolation from tkinter: the real
     Tk.__init__ is neutralized, the inherited Tk methods the constructor calls
@@ -42,12 +42,22 @@ def display():
     active for the duration of each test so methods that reconfigure widgets
     (apply_theme/_apply_font) also run without a real display.
 
+    The persisted settings handed to the constructor can be customized per test by
+    parametrizing the fixture indirectly (e.g.
+    @pytest.mark.parametrize("display", [{"theme": "Light"}], indirect=True)); when
+    not parametrized, no settings are supplied and the display falls back to its
+    defaults.
+
     Returns:
         types.SimpleNamespace: Holds the constructed display (`display`), the
             mocked Tk methods (`title`, `geometry`, `resizable`, `configure`,
             `config`), the mocked ArgumentProvider instance (`arg_provider`), and
-            the process callback passed at construction (`process_callback`).
+            the callbacks passed at construction (`process_callback`,
+            `read_file_callback`, `save_config_callback`, `save_settings_callback`).
     """
+
+    # Settings supplied indirectly by a test, or None when not parametrized
+    settings = getattr(request, "param", None)
 
     with (
         patch.object(tk.Tk, "__init__", return_value=None),
@@ -73,13 +83,16 @@ def display():
         callback = MagicMock()
         read_file_callback = MagicMock()
         save_config_callback = MagicMock()
+        save_settings_callback = MagicMock()
 
         built_display = InvoiceAppDisplay(
             process_callback=callback,
             read_file_callback=read_file_callback,
             save_config_callback=save_config_callback,
+            save_settings_callback=save_settings_callback,
             title="Invoice Processor",
             window_resolution="750x750",
+            settings=settings,
         )
 
         yield SimpleNamespace(
@@ -93,6 +106,7 @@ def display():
             process_callback=callback,
             read_file_callback=read_file_callback,
             save_config_callback=save_config_callback,
+            save_settings_callback=save_settings_callback,
         )
 
 
@@ -132,7 +146,54 @@ def test_init_sets_default_state(display):
     assert display.display.process_callback is display.process_callback
     assert display.display.read_file_callback is display.read_file_callback
     assert display.display.save_config_callback is display.save_config_callback
+    assert display.display.save_settings_callback is display.save_settings_callback
     assert display.display.argument_provider is display.arg_provider
+
+
+@pytest.mark.parametrize(
+    "display",
+    [{"theme": "Light", "font_family": "Arial", "font_size": "18"}],
+    indirect=True,
+)
+def test_init_restores_persisted_settings(display):
+    """
+    Verifies that __init__ restores the theme, font family, and font size from the
+    persisted settings, resolving the saved theme name back to its Theme and
+    converting the stored font size string to an int.
+
+    Args:
+        display (pytest.fixture): Provides the display built with persisted settings
+    """
+
+    assert display.display.current_theme == LIGHT
+    assert display.display.current_font_family == "Arial"
+    assert display.display.current_font_size == 18
+
+
+@pytest.mark.parametrize("display", [{"theme": "Nonexistent"}], indirect=True)
+def test_init_unknown_theme_falls_back_to_default(display):
+    """
+    Verifies that __init__ falls back to the default theme when the persisted
+    theme name does not match any known theme.
+
+    Args:
+        display (pytest.fixture): Provides the display built with an unknown theme
+    """
+
+    assert display.display.current_theme == DARK
+
+
+@pytest.mark.parametrize("display", [{"font_size": "not-a-number"}], indirect=True)
+def test_init_non_numeric_font_size_falls_back_to_default(display):
+    """
+    Verifies that __init__ falls back to the default font size when the persisted
+    font size cannot be parsed as an integer.
+
+    Args:
+        display (pytest.fixture): Provides the display built with a bad font size
+    """
+
+    assert display.display.current_font_size == DEFAULT_FONT_SIZE
 
 
 ###############################################################################
@@ -679,6 +740,9 @@ def test_apply_theme_updates_state_and_widgets(display):
         bg=LIGHT.bg_entry, fg=LIGHT.fg_text, insertbackground=LIGHT.fg_text
     )
 
+    # The chosen theme is persisted by name so it can be restored on next launch
+    display.save_settings_callback.assert_called_once_with("theme", LIGHT.name)
+
 
 ###############################################################################
 ###             Tests InvoiceAppDisplay -> apply_font_family()              ###
@@ -700,6 +764,9 @@ def test_apply_font_family_updates_state_and_widgets(display):
         font=("Arial", DEFAULT_FONT_SIZE, "bold")
     )
 
+    # The chosen font family is persisted so it can be restored on next launch
+    display.save_settings_callback.assert_called_once_with("font_family", "Arial")
+
 
 ###############################################################################
 ###              Tests InvoiceAppDisplay -> apply_font_size()               ###
@@ -720,3 +787,6 @@ def test_apply_font_size_updates_state_and_widgets(display):
     display.display.output_box.configure.assert_called_once_with(
         font=(DEFAULT_FONT_FAMILY, 20, "bold")
     )
+
+    # The chosen size is persisted as a string so it can be restored on next launch
+    display.save_settings_callback.assert_called_once_with("font_size", "20")

--- a/tests/SettingsRepository_tests.py
+++ b/tests/SettingsRepository_tests.py
@@ -1,0 +1,180 @@
+import sqlite3
+import pytest
+from types import SimpleNamespace
+from unittest.mock import patch, MagicMock
+
+from source.SettingsRepository import SettingsRepository
+
+
+###############################################################################
+###                   SettingsRepository -> Test Fixture                    ###
+###############################################################################
+@pytest.fixture
+def settings_repo():
+    """
+    Builds a SettingsRepository with sqlite3 and the database path fully mocked, so
+    no real database file is created or touched. The patches stay active for the
+    duration of each test so methods that open their own connection also run
+    against the mocks.
+
+    Returns:
+        types.SimpleNamespace: Holds the constructed repository (`repo`), the
+            patched sqlite3.connect (`connect`), the connection object yielded by
+            the `with` statement (`connection`), the mocked database path
+            (`db_path`), and the mocked error reporter (`report_error`).
+    """
+
+    with (
+        patch("source.SettingsRepository.sqlite3.connect") as mock_connect,
+        patch("source.SettingsRepository.SETTINGS_DB_PATH") as mock_db_path,
+    ):
+
+        # The object bound by `with sqlite3.connect(...) as connection`
+        mock_connection = mock_connect.return_value.__enter__.return_value
+
+        report_error = MagicMock()
+        repo = SettingsRepository(report_error=report_error)
+
+        yield SimpleNamespace(
+            repo=repo,
+            connect=mock_connect,
+            connection=mock_connection,
+            db_path=mock_db_path,
+            report_error=report_error,
+        )
+
+
+###############################################################################
+###             Tests SettingsRepository -> initialize_database()           ###
+###############################################################################
+def test_init_creates_data_dir_and_settings_table(settings_repo):
+    """
+    Verifies that constructing the repository ensures the data directory exists and
+    creates the settings table if it is not already present.
+
+    Args:
+        settings_repo (pytest.fixture): Provides the repository and its mocks
+    """
+
+    # The data directory is created before SQLite opens the database file
+    settings_repo.db_path.parent.mkdir.assert_called_once_with(
+        parents=True, exist_ok=True
+    )
+
+    # The settings table is created if it does not already exist
+    settings_repo.connection.execute.assert_called_once_with(
+        "CREATE TABLE IF NOT EXISTS settings (key TEXT PRIMARY KEY, value TEXT)"
+    )
+
+
+def test_initialize_database_error_is_reported(settings_repo):
+    """
+    Verifies that a sqlite3 failure while initializing the database is surfaced
+    through the error reporter rather than raised.
+
+    Args:
+        settings_repo (pytest.fixture): Provides the repository and its mocks
+    """
+
+    # The next database operation fails
+    settings_repo.connection.execute.side_effect = sqlite3.Error("boom")
+
+    # Re-running initialization should swallow the error and report it
+    settings_repo.repo.initialize_database()
+
+    settings_repo.report_error.assert_called_once()
+
+
+###############################################################################
+###               Tests SettingsRepository -> get_all_settings()            ###
+###############################################################################
+def test_get_all_settings_returns_mapping(settings_repo):
+    """
+    Verifies that get_all_settings selects every row and returns the keys and
+    values as a dict.
+
+    Args:
+        settings_repo (pytest.fixture): Provides the repository and its mocks
+    """
+
+    # The database returns two stored settings
+    settings_repo.connection.execute.return_value.fetchall.return_value = [
+        ("theme", "Ocean"),
+        ("font_size", "14"),
+    ]
+
+    result = settings_repo.repo.get_all_settings()
+
+    # The rows are returned as a key/value dict
+    assert result == {"theme": "Ocean", "font_size": "14"}
+    settings_repo.connection.execute.assert_called_with(
+        "SELECT key, value FROM settings"
+    )
+
+
+def test_get_all_settings_empty_returns_empty_dict(settings_repo):
+    """
+    Verifies that get_all_settings returns an empty dict when the database holds no
+    settings.
+
+    Args:
+        settings_repo (pytest.fixture): Provides the repository and its mocks
+    """
+
+    settings_repo.connection.execute.return_value.fetchall.return_value = []
+
+    assert settings_repo.repo.get_all_settings() == {}
+
+
+def test_get_all_settings_error_reports_and_returns_empty(settings_repo):
+    """
+    Verifies that a sqlite3 failure while reading settings is reported and results
+    in an empty dict rather than an exception.
+
+    Args:
+        settings_repo (pytest.fixture): Provides the repository and its mocks
+    """
+
+    settings_repo.connection.execute.side_effect = sqlite3.Error("boom")
+
+    result = settings_repo.repo.get_all_settings()
+
+    assert result == {}
+    settings_repo.report_error.assert_called_once()
+
+
+###############################################################################
+###                Tests SettingsRepository -> save_setting()               ###
+###############################################################################
+def test_save_setting_upserts_key_and_value(settings_repo):
+    """
+    Verifies that save_setting issues an upsert with the given key and value so an
+    existing setting is updated rather than duplicated.
+
+    Args:
+        settings_repo (pytest.fixture): Provides the repository and its mocks
+    """
+
+    settings_repo.repo.save_setting("theme", "Forest")
+
+    settings_repo.connection.execute.assert_called_with(
+        "INSERT INTO settings (key, value) VALUES (?, ?) "
+        "ON CONFLICT(key) DO UPDATE SET value=excluded.value",
+        ("theme", "Forest"),
+    )
+
+
+def test_save_setting_error_is_reported(settings_repo):
+    """
+    Verifies that a sqlite3 failure while saving a setting is surfaced through the
+    error reporter rather than raised.
+
+    Args:
+        settings_repo (pytest.fixture): Provides the repository and its mocks
+    """
+
+    settings_repo.connection.execute.side_effect = sqlite3.Error("boom")
+
+    settings_repo.repo.save_setting("theme", "Forest")
+
+    settings_repo.report_error.assert_called_once()


### PR DESCRIPTION
## Summary

User-controlled settings (theme, font family, font size) previously lived only in memory and were lost on every restart. This adds a SQLite-backed `SettingsRepository` that saves settings to `data/settings.db` and restores them on startup.

Scope is **settings only**, as discussed. The issue's optional config-file → DB migration is deliberately deferred (it would ripple into the integration test, `FileEditorWindow`, and the private `automated-invoice-testing` submodule) and is better handled as its own future issue.

## Changes

- **`source/SettingsRepository.py` (new)** — owns all SQLite I/O via the stdlib `sqlite3` (no new dependency). Generic `settings(key, value)` table, upsert-based `save_setting`, `get_all_settings`, on-demand `data/` dir + schema creation, and an injectable `report_error` callback matching `InvoiceAppFileIO`'s convention.
- **`InvoiceAppController`** — constructs the repository, reads saved settings before building the display, passes them in plus a `handle_save_setting` callback, and wires the GUI error popup into the repo.
- **`InvoiceAppDisplay`** — resolves saved values *before* `build_widgets()` runs, so the UI comes up already themed (no flicker, no redundant writes). `apply_theme`/`apply_font_family`/`apply_font_size` now persist immediately on each change. Missing keys, unknown theme names, and non-numeric font sizes fall back to defaults.
- **`color_theme.py`** — adds a `THEME_BY_NAME` lookup so a saved theme name resolves back to its `Theme` (auto-includes future themes).
- **`constants.py`** — adds `DATA_DIR`, `SETTINGS_DB_PATH`, and shared setting-key constants.
- **`.gitignore`** — ignores `data/` (per-machine user state).

## Design notes

The implementation mirrors the existing config-save seam (`save_config_callback` → `handle_save_config`), so settings persistence follows an established pattern rather than introducing a new one. The repository is a focused, dependency-injected component per the repo's SOLID conventions.

## Testing

- Full suite: **122 passed**, total coverage **99.83%**, with `SettingsRepository.py` at **100%** — above the 90% gate.
- Added `tests/SettingsRepository_tests.py` (schema init, get/save, empty DB, and error-reporting paths with mocked `sqlite3`) and extended the display and controller tests for the new wiring.
- Validated against real SQLite outside the mocked unit tests: confirmed DB creation, empty-DB read, and that re-saving a key upserts (updates) rather than duplicates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)