### PR TITLE
Add tag-triggered CI release workflow (#56)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,91 @@
+name: Release Workflow
+
+# Build and publish a release whenever a version tag (e.g. v3.2.0) is pushed.
+on:
+  push:
+    tags: [ 'v*' ]
+
+# Allow the job to create the GitHub Release and upload the packaged asset
+permissions:
+  contents: write
+
+jobs:
+  release:
+
+    # Give the job a name to link into the Github Rules UI
+    name: Build and Publish Release
+    runs-on: windows-latest
+
+    # Make sure that windows is using bash shell, since all terminal commands in this job are bash style
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+    # Checkout repo, including the private submodule that supplies packaging resources
+    - name: Checkout repo
+      uses: actions/checkout@v4
+      with:
+        submodules: recursive
+        token: ${{ secrets.CUSTOMER_DATA_PAT }}
+
+    # Set up Python environment
+    - name: Set up Python environment
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.11.9"
+
+    # Install project dependencies (dev set, needed to run the tests below)
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements/dev.txt
+
+    # Fail the release if the pushed tag does not match the in-app version,
+    # so a release can never ship with an About box that disagrees with the tag
+    - name: Verify tag matches source version
+      run: |
+        TAG="${GITHUB_REF_NAME#v}"
+        VERSION="$(python -c 'from source import constants; print(constants.VERSION)')"
+        echo "Tag version: $TAG / constants.py VERSION: $VERSION"
+        if [[ "$TAG" != "$VERSION" ]]; then
+            echo "::error::Tag ($TAG) does not match source/constants.py VERSION ($VERSION)."
+            exit 1
+        fi
+
+    # Copy integration test data into the expected input directory
+    - name: Copy integration test data
+      run: |
+        ./scripts/copy_resources.sh
+
+    # Run unit tests against the tagged commit
+    - name: Run unit tests
+      run: |
+        pytest tests/*
+
+    # Run integration tests and verify output matches the canonical results
+    - name: Run integration test
+      run: |
+        python main.py --integration-test
+        cp ./automated-invoice-testing/canonical_correct_results.txt .
+        if diff -q ./logs/results.txt canonical_correct_results.txt >/dev/null; then
+            echo -e "\e[1;3;32mOutput matches, tests pass.\e[0m"
+        else
+            echo -e "\e[1;3;31mOutput mismatch, tests do not pass.\e[0m"
+            exit 1
+        fi
+
+    # Package the release executable + resources into release/FishbowlInvoiceTool.zip
+    - name: Package release
+      run: |
+        ./scripts/package_release.sh false
+
+    # Create the GitHub Release with the packaged zip and auto-generated notes
+    - name: Create GitHub Release
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        gh release create "$GITHUB_REF_NAME" \
+          release/FishbowlInvoiceTool.zip \
+          --title "$GITHUB_REF_NAME" \
+          --generate-notes

--- a/scripts/package_release.sh
+++ b/scripts/package_release.sh
@@ -36,15 +36,10 @@ fi
 # Save the argument specifying whether to populate the Invoices/ folder
 POPULATE_INVOICES="$1"
 
-# Check virtual environment, exit if already in one to create a fresh one
-if [[ -n "${VIRTUAL_ENV:-}" ]]; then
-    echo "Exiting current virtual environment to create a fresh one: $VIRTUAL_ENV"
-    deactivate
-fi
-
-# Run a git clean to clean up the project tree before packaging, including removing
-# the old virtual environment if necessary
-git clean -fdxf
+# Detect whether we are running in a CI environment (GitHub Actions sets CI=true).
+# In CI the workspace is already a clean, freshly-checked-out tree with the submodule
+# fetched via a token, so the local-developer-only environment prep below is skipped.
+IS_CI="${CI:-false}"
 
 # Get the location of this script, and use it to derive the project directory
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -56,13 +51,30 @@ RESOURCES_DIR="$ROOT_DIR/automated-invoice-testing/resources"
 echo "Derived project root: $ROOT_DIR"
 echo "Resources location: $RESOURCES_DIR"
 
-# Check if the submodule directory is empty or missing
-if [ ! -f "$ROOT_DIR/automated-invoice-testing/" ]; then
-    echo "Testing resources not found. Attempting to initialize submodules..."
-    git submodule update --init --recursive
+# Local-developer-only environment prep. These steps prepare a developer's working tree
+# for a clean build; in CI they are unnecessary and the git clean would delete the
+# freshly checked-out submodule, so guard them behind the CI check.
+if [[ "$IS_CI" == "true" ]]; then
+    echo "CI detected; skipping local env prep (venv deactivate, git clean, submodule init)."
+else
+    # Exit any active virtual environment so a fresh one can be created below
+    if [[ -n "${VIRTUAL_ENV:-}" ]]; then
+        echo "Exiting current virtual environment to create a fresh one: $VIRTUAL_ENV"
+        deactivate
+    fi
+
+    # Run a git clean to clean up the project tree before packaging, including removing
+    # the old virtual environment if necessary
+    git clean -fdxf
+
+    # Initialize the submodule if its resources are missing
+    if [[ ! -d "$RESOURCES_DIR" ]]; then
+        echo "Testing resources not found. Attempting to initialize submodules..."
+        git submodule update --init --recursive
+    fi
 fi
 
-# Ensure that the source and destination directories exist
+# Ensure that the submodule resources exist before continuing
 if [[ ! -d "$RESOURCES_DIR" ]]; then
   echo "Error: Submodule resources not found at: $RESOURCES_DIR"
   echo "Did you forget to run 'git submodule update --init'?"


### PR DESCRIPTION
## Summary
Implements automated releases for the FishbowlInvoiceTool. Pushing a `v*` tag now packages and publishes a GitHub Release automatically, reusing the existing `scripts/package_release.sh`.

Closes #56.

### `.github/workflows/release.yml` (new)
Triggers on `v*` tags, runs on `windows-latest`, and:
- Checks out with the private `automated-invoice-testing` submodule via `secrets.CUSTOMER_DATA_PAT`
- **Verifies the pushed tag matches `source/constants.py` `VERSION`** and fails the release on mismatch (prevents shipping a build whose About box disagrees with the tag)
- Runs **unit tests + the integration test** on the tagged commit before building
- Packages via `scripts/package_release.sh false`
- Creates the GitHub Release with `release/FishbowlInvoiceTool.zip` and **auto-generated notes** (`gh release create --generate-notes`)

### `scripts/package_release.sh` (streamlined for CI)
- Auto-detects CI (`CI=true`) and skips the local-developer-only env prep (venv deactivate, `git clean -fdxf`, submodule init). On a runner the workspace is already a clean checkout with the submodule fetched via token, and the `git clean -fdxf` would otherwise **delete the checked-out submodule**.
- Fixes the submodule check: the previous `[ ! -f ".../automated-invoice-testing/" ]` test (`-f` on a directory is always false) re-initialized the submodule on *every* local run; now checks the resources directory with `-d`.
- The build/package core (fresh venv → release deps → PyInstaller → zip) is unchanged and runs identically locally and in CI.

## Test plan
- [x] `bash -n scripts/package_release.sh` passes
- [x] `release.yml` is valid YAML
- [x] CI guard verified firing locally (`CI=true ./scripts/package_release.sh false` logs "CI detected; skipping local env prep")
- [ ] End-to-end: push a matching version tag and confirm the workflow builds + publishes the release
- [ ] Negative: push a mismatched tag (e.g. `v9.9.9`) and confirm the version-check step fails before packaging

🤖 Generated with [Claude Code](https://claude.com/claude-code)