### PR TITLE
Fix release archive: produce a real .zip instead of a tar.gz

### DIFF
--- a/scripts/package_release.sh
+++ b/scripts/package_release.sh
@@ -142,10 +142,14 @@ if [[ "$POPULATE_INVOICES" == "true" ]]; then
     cp -a "$RESOURCES_DIR/Invoices/." "$INVOICES_DIR/"
 fi
 
-# Zip up the release folder for distribution
+# Zip up the release folder for distribution. Use Python's zipfile module (the build
+# venv is active here, so python is guaranteed available) to produce a real .zip that
+# standard tools can open. This is portable across the Windows/Linux cases above and
+# avoids tar, which only produces gzip tarballs. cd into release/ first so the archive
+# stores the relative "FishbowlInvoiceTool/" folder rather than absolute paths.
 echo "Creating zip archive of the release..."
 cd "$ROOT_DIR/release"
-tar -czvf "FishbowlInvoiceTool.zip" "$RELEASE_DIR"
+python -m zipfile -c "FishbowlInvoiceTool.zip" "FishbowlInvoiceTool"
 
 # Exit virtual environment on script exit
 echo "Deactivating virtual environment: $VIRTUAL_ENV"

--- a/scripts/package_release.sh
+++ b/scripts/package_release.sh
@@ -142,14 +142,15 @@ if [[ "$POPULATE_INVOICES" == "true" ]]; then
     cp -a "$RESOURCES_DIR/Invoices/." "$INVOICES_DIR/"
 fi
 
-# Zip up the release folder for distribution. Use Python's zipfile module (the build
-# venv is active here, so python is guaranteed available) to produce a real .zip that
-# standard tools can open. This is portable across the Windows/Linux cases above and
-# avoids tar, which only produces gzip tarballs. cd into release/ first so the archive
-# stores the relative "FishbowlInvoiceTool/" folder rather than absolute paths.
+# Zip up the release folder for distribution. Use Python's shutil.make_archive (the
+# build venv is active here, so python is guaranteed available) to produce a real,
+# DEFLATE-compressed .zip that standard tools can open. This is portable across the
+# Windows/Linux cases above and avoids tar, which only produces gzip tarballs. The
+# base_dir "FishbowlInvoiceTool" makes the archive store that relative folder rather
+# than absolute paths.
 echo "Creating zip archive of the release..."
 cd "$ROOT_DIR/release"
-python -m zipfile -c "FishbowlInvoiceTool.zip" "FishbowlInvoiceTool"
+python -c "import shutil; shutil.make_archive('FishbowlInvoiceTool', 'zip', '.', 'FishbowlInvoiceTool')"
 
 # Exit virtual environment on script exit
 echo "Deactivating virtual environment: $VIRTUAL_ENV"


### PR DESCRIPTION
## Problem
The release published by the new workflow can't be opened — unzip tools report the `.zip` is invalid. `scripts/package_release.sh` named the artifact `FishbowlInvoiceTool.zip` but created it with `tar -czvf`, which produces a **gzip tarball**, not a zip. (Secondary issue: it passed an absolute path to `tar`, embedding the full path in the archive.)

## Fix
Build the archive with Python's `shutil.make_archive` instead:
```bash
cd "$ROOT_DIR/release"
python -c "import shutil; shutil.make_archive('FishbowlInvoiceTool', 'zip', '.', 'FishbowlInvoiceTool')"
```
- Produces a genuine, **DEFLATE-compressed** `.zip` standard tools can open (zlib is always present in CPython).
- Portable across the Windows/Linux cases the script already handles; python is guaranteed present (the build venv is active at this point).
- `base_dir="FishbowlInvoiceTool"` stores the relative folder, so entries are relative (no absolute paths).

## Verification
Standalone test of the command on a sample folder:
- `file` reports `Zip archive data` (was: gzip tarball)
- `zipfile.testzip()` returns `None` (no corruption)
- File entries use `compress_type=8` (DEFLATE); a 200 KB sample compressed to ~950 bytes
- Archive contains `FishbowlInvoiceTool/AutoInvoiceProc.exe`, `USER_GUIDE.txt`, `Configs/...` at the expected relative paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)