### PR TITLE
Add Inno Setup installer script (#57)

### DIFF
--- a/scripts/installer.iss
+++ b/scripts/installer.iss
@@ -1,0 +1,97 @@
+; ###########################################################################
+; Inno Setup script for the Fishbowl Invoice Tool.
+;
+; Produces a per-user, no-UAC installer (FishbowlInvoiceTool_Setup.exe) from
+; the release payload that scripts/package_release.sh writes to
+; release/FishbowlInvoiceTool/. Designed so that UPGRADES replace the program
+; files (exe + user guide) while PRESERVING the customer's edited Configs/ and
+; any invoices they have dropped into Invoices/.
+;
+; The app (see source/constants.py) reads/writes logs/, data/, Configs/ and
+; Invoices/ RELATIVE TO ITS OWN EXE, so it is installed per-user into a
+; writable location ({localappdata}\Programs) rather than Program Files.
+;
+; Build (run from the repo root, after building the release payload):
+;   "C:\Program Files (x86)\Inno Setup 6\ISCC.exe" /DAppVersion=3.1.2 scripts\installer.iss
+;
+; AppVersion is passed in via /D so source/constants.py stays the single source
+; of truth; the #ifndef below provides a fallback for a bare manual compile.
+; ###########################################################################
+
+#define AppName "Fishbowl Invoice Tool"
+#ifndef AppVersion
+  #define AppVersion "0.0.0"
+#endif
+#define AppExeName "AutoInvoiceProc.exe"
+#define Publisher "Hammond Software"
+
+; Release payload produced by scripts/package_release.sh, relative to this .iss.
+#define SourceRoot "..\release\FishbowlInvoiceTool"
+
+; Optional installer icon. No .ico ships in the repo yet, so reference it only
+; if present; once scripts\assets\app.ico is added it is picked up automatically.
+#define IconFile "assets\app.ico"
+#define HaveIcon FileExists(AddBackslash(SourcePath) + IconFile)
+
+[Setup]
+; A stable AppId is what lets Inno recognize an existing install and upgrade it
+; in place. Do NOT change this GUID across versions.
+AppId={{4E1C7A2F-9B3D-4F6A-8C21-5D9E0B7A1F34}
+AppName={#AppName}
+AppVersion={#AppVersion}
+AppVerName={#AppName} {#AppVersion}
+AppPublisher={#Publisher}
+VersionInfoVersion={#AppVersion}
+VersionInfoCompany={#Publisher}
+VersionInfoDescription={#AppName} Setup
+
+; Per-user install, no admin prompt. {autopf} under lowest privileges resolves
+; to %LOCALAPPDATA%\Programs, which the app can freely write into at runtime.
+PrivilegesRequired=lowest
+DefaultDirName={autopf}\FishbowlInvoiceTool
+DefaultGroupName={#AppName}
+DisableProgramGroupPage=yes
+
+WizardStyle=modern
+Compression=lzma2/max
+SolidCompression=yes
+
+OutputDir=..\release
+OutputBaseFilename=FishbowlInvoiceTool_Setup
+UninstallDisplayName={#AppName}
+UninstallDisplayIcon={app}\{#AppExeName}
+#if HaveIcon
+SetupIconFile={#IconFile}
+#endif
+
+[Tasks]
+Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
+
+[Files]
+; Program files: always replaced on upgrade.
+Source: "{#SourceRoot}\{#AppExeName}"; DestDir: "{app}"; Flags: ignoreversion
+Source: "{#SourceRoot}\USER_GUIDE.txt"; DestDir: "{app}"; Flags: ignoreversion
+; Config files: ship defaults on a clean install, but never overwrite a
+; customer's edits on upgrade (onlyifdoesntexist) and never delete on
+; uninstall (uninsneveruninstall) -- this is the "preserveexisting" behavior.
+Source: "{#SourceRoot}\Configs\*"; DestDir: "{app}\Configs"; Flags: onlyifdoesntexist uninsneveruninstall recursesubdirs createallsubdirs
+; Invoices: preserve any the customer has added; tolerate an empty/missing
+; source folder (package_release.sh only populates it when run with `true`).
+Source: "{#SourceRoot}\Invoices\*"; DestDir: "{app}\Invoices"; Flags: onlyifdoesntexist uninsneveruninstall recursesubdirs createallsubdirs skipifsourcedoesntexist
+
+[Dirs]
+; Guarantee the app's writable folders exist even when shipped empty, and keep
+; the data-bearing ones on uninstall.
+Name: "{app}\logs"
+Name: "{app}\data"
+Name: "{app}\Configs"; Flags: uninsneveruninstall
+Name: "{app}\Invoices"; Flags: uninsneveruninstall
+
+[Icons]
+Name: "{group}\{#AppName}"; Filename: "{app}\{#AppExeName}"
+Name: "{group}\User Guide"; Filename: "{app}\USER_GUIDE.txt"
+Name: "{group}\Uninstall {#AppName}"; Filename: "{uninstallexe}"
+Name: "{autodesktop}\{#AppName}"; Filename: "{app}\{#AppExeName}"; Tasks: desktopicon
+
+[Run]
+Filename: "{app}\{#AppExeName}"; Description: "{cm:LaunchProgram,{#AppName}}"; Flags: nowait postinstall skipifsilent


### PR DESCRIPTION
## Summary
Part 2 of the 3-part release-automation effort (#56 done, #58 to follow). Adds `scripts/installer.iss`, an Inno Setup script that packages the `release/FishbowlInvoiceTool/` payload produced by `scripts/package_release.sh` into a professional, per-user `FishbowlInvoiceTool_Setup.exe`.

Closes #57.

## Key behavior
- **Per-user, no-UAC install** to `%LOCALAPPDATA%\Programs\FishbowlInvoiceTool` (`PrivilegesRequired=lowest`), so the app can keep writing `logs/`, `data/`, `Configs/`, `Invoices/` next to its own exe at runtime (see `source/constants.py`).
- **Version via `/DAppVersion`** so `source/constants.py` stays the single source of truth, with a fallback for bare manual compiles.
- **Upgrades preserve customer data**: the exe and `USER_GUIDE.txt` are replaced (`ignoreversion`), but customer-edited `Configs/` and any added `Invoices/` are kept (`onlyifdoesntexist` + `uninsneveruninstall`). Uninstall leaves that data behind too.
- Start Menu group, optional desktop-icon task, launch-on-finish, and an `#if FileExists` guard so a future `scripts/assets/app.ico` is picked up automatically without breaking the compile.

## Build / test locally
```
./scripts/package_release.sh false                                   # build payload
& "$env:LOCALAPPDATA\Programs\Inno Setup 6\ISCC.exe" /DAppVersion=3.1.2 "scripts\installer.iss"
```

## Manual verification (all passed)
- **Fresh install** — per-user location, no UAC, all files + empty `logs/data/Invoices`, correct Add/Remove Programs entry.
- **Upgrade** — edited config + user invoice preserved; program files replaced.
- **Uninstall** — program files + registry entry removed; `Configs/` and `Invoices/` retained.

## Does Inno need to be a repo dependency?
No — `ISCC.exe` is a build-time tool (like PyInstaller), **not** a Python/runtime dependency, so it does not belong in `requirements/*.txt`. Installing it in CI and documenting it as a build prerequisite are deferred to #58.

## Follow-ups (out of scope)
- #58 will invoke `ISCC` from `package_release.sh`, derive `/DAppVersion` from `constants.VERSION`, install Inno in CI, and document the prerequisite.
- Add `scripts/assets/app.ico` to brand the installer/shortcuts (the script already detects it).
- Code signing (Authenticode) to avoid SmartScreen "Unknown Publisher" warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)