### PR TITLE
Build Inno Setup installer in release script and CI (#58)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,7 +75,15 @@ jobs:
             exit 1
         fi
 
-    # Package the release executable + resources into release/FishbowlInvoiceTool.zip
+    # Install Inno Setup so package_release.sh can additionally build the Windows installer
+    # (FishbowlInvoiceTool_Setup.exe). Chocolatey is preinstalled on windows-latest and installs
+    # ISCC.exe to the default location the packaging script probes.
+    - name: Install Inno Setup
+      run: |
+        choco install innosetup --no-progress -y
+
+    # Package the release executable + resources into release/FishbowlInvoiceTool.zip, and (since
+    # Inno Setup is now installed) release/FishbowlInvoiceTool_Setup.exe
     - name: Package release
       run: |
         ./scripts/package_release.sh false
@@ -87,5 +95,6 @@ jobs:
       run: |
         gh release create "$GITHUB_REF_NAME" \
           release/FishbowlInvoiceTool.zip \
+          release/FishbowlInvoiceTool_Setup.exe \
           --title "$GITHUB_REF_NAME" \
           --generate-notes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ A Python/tkinter desktop app that parses Fishbowl-generated invoice PDFs and com
 - Run a single test file: `pytest tests/Invoice_tests.py`
 - Run a single test: `pytest tests/processor_utilities_tests.py::test_search_text_by_re_order_number_correct_format`
 - Run with coverage (matches CI): `pytest --cov=./ --cov-report=xml tests/*`
-- Package a release executable: `./scripts/package_release.sh false` (pass `true` to also bundle sample invoices). Builds via PyInstaller into `release/FishbowlInvoiceTool/` and zips it.
+- Package a release executable: `./scripts/package_release.sh false` (pass `true` to also bundle sample invoices). Builds via PyInstaller into `release/FishbowlInvoiceTool/` and zips it. On Windows with Inno Setup installed, it additionally builds `release/FishbowlInvoiceTool_Setup.exe` (via `scripts/installer.iss`); this step is skipped on Linux or when Inno Setup is absent.
 
 ## Git Workflow (when working on a GitHub issue)
 

--- a/USER_GUIDE.txt
+++ b/USER_GUIDE.txt
@@ -1,43 +1,57 @@
 Welcome to the Automated Invoice Processing Tool.
 
+Installing the tool:
+
+If you received 'FishbowlInvoiceTool_Setup.exe', simply double-click it and follow the prompts
+to install the application. The installer runs without administrator rights and installs the
+tool just for your user account. When it finishes, you can launch the tool from the
+"Fishbowl Invoice Tool" Start Menu shortcut (and a desktop icon, if you chose to create one).
+
+If a newer version is released, run the new 'FishbowlInvoiceTool_Setup.exe' to upgrade in place.
+Your edited configuration files in the 'Configs' folder and any invoices you placed in the
+'Invoices' folder are preserved across upgrades and are not removed if you uninstall.
+
+If you instead received the 'FishbowlInvoiceTool.zip' file, just extract it anywhere and run
+'AutoInvoiceProc.exe' from the extracted folder -- no installation is required.
+
 To use the tool:
 
-1) Download any Fishbowl invoice you would like to process as a '.pdf' file, and place them
+Download any Fishbowl invoice you would like to process as a '.pdf' file, and place them
 into the 'Invoices' folder.
 
-2) Run 'AutoInvoiceProc.exe' to launch the application.
+Run 'AutoInvoiceProc.exe' to launch the application.
 
-3) Press "Edit" on the menu bar, and check each configuration file to make sure they are correct.
+Press "Edit" on the menu bar, and check each configuration file to make sure they are correct.
 
-    - Ensure that Sales_Reps.txt contains a list of all possible sales reps that could
-	  be listed on an invoice. If a sales rep's name code shows up on an invoice and
-	  there is no corresponding entry in this file to decode it, the sales rep will
-	  be blank on the invoice report.
+  - Ensure that Sales_Reps.txt contains a list of all possible sales reps that could
+	be listed on an invoice. If a sales rep's name code shows up on an invoice and
+	there is no corresponding entry in this file to decode it, the sales rep will
+	be blank on the invoice report.
 
-	  Any entries must be input as xxxxx=yyyyy where 'xxxxx' is the sales rep as it appears 
-	  on the invoice, and 'yyyyy' = is the name of the sales rep you would like the tool to 
-	  display after processing the invoice.
+	Any entries must be input as xxxxx=yyyyy where 'xxxxx' is the sales rep as it appears 
+	on the invoice, and 'yyyyy' = is the name of the sales rep you would like the tool to 
+	display after processing the invoice.
 
-	- Ensure that Payment_Terms.txt has been populated with an exhaustive list of all
-	  possible payment terms that can appear on an invoice. If a payment term is encountered
-	  that is not on this list, it will be blank on the invoice report.
+  - Ensure that Payment_Terms.txt has been populated with an exhaustive list of all
+	possible payment terms that can appear on an invoice. If a payment term is encountered
+	that is not on this list, it will be blank on the invoice report.
 
-	  Any entries must be input as it will appear on the invoice, one per line.
+	Any entries must be input as it will appear on the invoice, one per line.
 
-	- Ensure that Cost_Criteria.txt contains all necessary information to discern between
-	  different cost types. I.E: shipping costs vs material costs vs labor costs.
+  - Ensure that Cost_Criteria.txt contains all necessary information to discern between
+	different cost types. I.E: shipping costs vs material costs vs labor costs.
 
-	  Any entries must be input as it will appear on the invoice, one per line.
+	Any entries must be input as it will appear on the invoice, one per line.
 
-4) To process invoices, follow one of the two actions:
+To process invoices, follow one of the two actions:
 	
-	1 - To use the app to process a single invoice at once, click the "Browse" button to open the file
-	    browser. The browser will automatically direct you to the Invoices folder. Select the invoice
-	    that you would like the process, and then click "Process This Invoice".
+  - To use the app to process a single invoice at once, click the "Browse" button to open the file
+	browser. The browser will automatically direct you to the Invoices folder. Select the invoice
+	that you would like the process, and then click "Process This Invoice".
 
-	2 - To process all invoices in the Invoices folder, simply click the "Process All Invoices" button.
+  - To process all invoices in the Invoices folder, simply click the "Process All Invoices" button.
 
-5) The output of the processed invoice(s) can be read in the output window below the buttons, or in the
-   results file that can be viewed by pressing "View" -> "Results.txt".
+The output of the processed invoice(s) can be read in the output window below the buttons, or in the
+results file that can be viewed by pressing "View" -> "Results.txt".
 
-6) Repeat until all invoices are processed, and then click "Exit" to close the program.
+Repeat until all invoices are processed, and then click "Exit" to close the program.

--- a/scripts/package_release.sh
+++ b/scripts/package_release.sh
@@ -152,6 +152,38 @@ echo "Creating zip archive of the release..."
 cd "$ROOT_DIR/release"
 python -c "import shutil; shutil.make_archive('FishbowlInvoiceTool', 'zip', '.', 'FishbowlInvoiceTool')"
 
+# Additionally build a double-click Windows installer (FishbowlInvoiceTool_Setup.exe) from the
+# populated release/FishbowlInvoiceTool payload using Inno Setup (scripts/installer.iss). Inno's
+# ISCC.exe is Windows-only, so this is skipped on Linux and on Windows machines without Inno
+# installed -- the .zip above is the guaranteed artifact. CI installs Inno so the installer is
+# always produced there.
+if [[ "$OS_TYPE" == "MINGW"* || "$OS_TYPE" == "CYGWIN"* || "$OS_TYPE" == "MSYS"* ]]; then
+    # Locate the Inno Setup compiler: explicit $ISCC override, then the default install
+    # location, then anything named iscc on PATH.
+    ISCC_EXE="${ISCC:-}"
+    if [[ -z "$ISCC_EXE" && -x "/c/Program Files (x86)/Inno Setup 6/ISCC.exe" ]]; then
+        ISCC_EXE="/c/Program Files (x86)/Inno Setup 6/ISCC.exe"
+    fi
+    if [[ -z "$ISCC_EXE" ]] && command -v iscc >/dev/null 2>&1; then
+        ISCC_EXE="$(command -v iscc)"
+    fi
+
+    if [[ -z "$ISCC_EXE" ]]; then
+        echo "Inno Setup (ISCC.exe) not found; skipping installer build. The release zip is still available."
+        echo "Install Inno Setup 6 or set the ISCC environment variable to build FishbowlInvoiceTool_Setup.exe."
+    else
+        # Pass the in-app version (the single source of truth in source/constants.py) to the
+        # installer. Use //D (double slash) so Git Bash/MSYS does not path-mangle the
+        # /DAppVersion argument into a filesystem path.
+        VERSION="$(cd "$ROOT_DIR" && python -c 'from source import constants; print(constants.VERSION)')"
+        echo "Building installer with Inno Setup ($ISCC_EXE) for version $VERSION..."
+        "$ISCC_EXE" //DAppVersion="$VERSION" "$ROOT_DIR/scripts/installer.iss"
+        echo "Created installer: $ROOT_DIR/release/FishbowlInvoiceTool_Setup.exe"
+    fi
+else
+    echo "Non-Windows OS ($OS_TYPE); skipping Inno Setup installer build (ISCC.exe is Windows-only)."
+fi
+
 # Exit virtual environment on script exit
 echo "Deactivating virtual environment: $VIRTUAL_ENV"
 deactivate


### PR DESCRIPTION
Closes #58 (Part 3 of the release automation work). Targets `release-automation`.

## What
Wires the existing `scripts/installer.iss` (added in #57) into the release flow so every release additionally produces a double-click Windows installer, `FishbowlInvoiceTool_Setup.exe`, alongside the existing `.zip`.

## Changes
- **`scripts/package_release.sh`** — after zipping, build the installer with Inno Setup's `ISCC.exe`. Windows-only; locates `ISCC` via `$ISCC` override → default install path → `PATH`. Passes the in-app version (`source/constants.py`) via `//DAppVersion=` (double-slash to avoid MSYS path mangling). **Skips with a notice (non-fatal)** on Linux or when Inno isn't installed, so the `.zip` stays the guaranteed artifact.
- **`.github/workflows/release.yml`** — `choco install innosetup` before packaging (so the script auto-builds the exe), and upload `FishbowlInvoiceTool_Setup.exe` as a release asset alongside the zip.
- **`USER_GUIDE.txt`** — end-user "Installing the tool" section (run the Setup.exe; per-user, no admin; upgrades preserve Configs/Invoices; zip fallback).
- **`CLAUDE.md`** — note the new installer output.

`scripts/installer.iss` is unchanged (it already accepts `/DAppVersion` and reads the release payload).

## Testing
- `bash -n scripts/package_release.sh` passes.
- Manual end-to-end test (install Inno, run `./scripts/package_release.sh false`, run/upgrade/uninstall the Setup.exe) is the remaining acceptance check called out in the issue — Inno Setup is not installed on the dev machine yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)