### PR TITLE
Add Inno Setup installer and integrate into release automation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,7 +75,15 @@ jobs:
             exit 1
         fi
 
-    # Package the release executable + resources into release/FishbowlInvoiceTool.zip
+    # Install Inno Setup so package_release.sh can additionally build the Windows installer
+    # (FishbowlInvoiceTool_Setup.exe). Chocolatey is preinstalled on windows-latest and installs
+    # ISCC.exe to the default location the packaging script probes.
+    - name: Install Inno Setup
+      run: |
+        choco install innosetup --no-progress -y
+
+    # Package the release executable + resources into release/FishbowlInvoiceTool.zip, and (since
+    # Inno Setup is now installed) release/FishbowlInvoiceTool_Setup.exe
     - name: Package release
       run: |
         ./scripts/package_release.sh false
@@ -87,5 +95,6 @@ jobs:
       run: |
         gh release create "$GITHUB_REF_NAME" \
           release/FishbowlInvoiceTool.zip \
+          release/FishbowlInvoiceTool_Setup.exe \
           --title "$GITHUB_REF_NAME" \
           --generate-notes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ A Python/tkinter desktop app that parses Fishbowl-generated invoice PDFs and com
 - Run a single test file: `pytest tests/Invoice_tests.py`
 - Run a single test: `pytest tests/processor_utilities_tests.py::test_search_text_by_re_order_number_correct_format`
 - Run with coverage (matches CI): `pytest --cov=./ --cov-report=xml tests/*`
-- Package a release executable: `./scripts/package_release.sh false` (pass `true` to also bundle sample invoices). Builds via PyInstaller into `release/FishbowlInvoiceTool/` and zips it.
+- Package a release executable: `./scripts/package_release.sh false` (pass `true` to also bundle sample invoices). Builds via PyInstaller into `release/FishbowlInvoiceTool/` and zips it. On Windows with Inno Setup installed, it additionally builds `release/FishbowlInvoiceTool_Setup.exe` (via `scripts/installer.iss`); this step is skipped on Linux or when Inno Setup is absent.
 
 ## Git Workflow (when working on a GitHub issue)
 

--- a/USER_GUIDE.txt
+++ b/USER_GUIDE.txt
@@ -1,43 +1,57 @@
 Welcome to the Automated Invoice Processing Tool.
 
+Installing the tool:
+
+If you received 'FishbowlInvoiceTool_Setup.exe', simply double-click it and follow the prompts
+to install the application. The installer runs without administrator rights and installs the
+tool just for your user account. When it finishes, you can launch the tool from the
+"Fishbowl Invoice Tool" Start Menu shortcut (and a desktop icon, if you chose to create one).
+
+If a newer version is released, run the new 'FishbowlInvoiceTool_Setup.exe' to upgrade in place.
+Your edited configuration files in the 'Configs' folder and any invoices you placed in the
+'Invoices' folder are preserved across upgrades and are not removed if you uninstall.
+
+If you instead received the 'FishbowlInvoiceTool.zip' file, just extract it anywhere and run
+'AutoInvoiceProc.exe' from the extracted folder -- no installation is required.
+
 To use the tool:
 
-1) Download any Fishbowl invoice you would like to process as a '.pdf' file, and place them
+Download any Fishbowl invoice you would like to process as a '.pdf' file, and place them
 into the 'Invoices' folder.
 
-2) Run 'AutoInvoiceProc.exe' to launch the application.
+Run 'AutoInvoiceProc.exe' to launch the application.
 
-3) Press "Edit" on the menu bar, and check each configuration file to make sure they are correct.
+Press "Edit" on the menu bar, and check each configuration file to make sure they are correct.
 
-    - Ensure that Sales_Reps.txt contains a list of all possible sales reps that could
-	  be listed on an invoice. If a sales rep's name code shows up on an invoice and
-	  there is no corresponding entry in this file to decode it, the sales rep will
-	  be blank on the invoice report.
+  - Ensure that Sales_Reps.txt contains a list of all possible sales reps that could
+	be listed on an invoice. If a sales rep's name code shows up on an invoice and
+	there is no corresponding entry in this file to decode it, the sales rep will
+	be blank on the invoice report.
 
-	  Any entries must be input as xxxxx=yyyyy where 'xxxxx' is the sales rep as it appears 
-	  on the invoice, and 'yyyyy' = is the name of the sales rep you would like the tool to 
-	  display after processing the invoice.
+	Any entries must be input as xxxxx=yyyyy where 'xxxxx' is the sales rep as it appears 
+	on the invoice, and 'yyyyy' = is the name of the sales rep you would like the tool to 
+	display after processing the invoice.
 
-	- Ensure that Payment_Terms.txt has been populated with an exhaustive list of all
-	  possible payment terms that can appear on an invoice. If a payment term is encountered
-	  that is not on this list, it will be blank on the invoice report.
+  - Ensure that Payment_Terms.txt has been populated with an exhaustive list of all
+	possible payment terms that can appear on an invoice. If a payment term is encountered
+	that is not on this list, it will be blank on the invoice report.
 
-	  Any entries must be input as it will appear on the invoice, one per line.
+	Any entries must be input as it will appear on the invoice, one per line.
 
-	- Ensure that Cost_Criteria.txt contains all necessary information to discern between
-	  different cost types. I.E: shipping costs vs material costs vs labor costs.
+  - Ensure that Cost_Criteria.txt contains all necessary information to discern between
+	different cost types. I.E: shipping costs vs material costs vs labor costs.
 
-	  Any entries must be input as it will appear on the invoice, one per line.
+	Any entries must be input as it will appear on the invoice, one per line.
 
-4) To process invoices, follow one of the two actions:
+To process invoices, follow one of the two actions:
 	
-	1 - To use the app to process a single invoice at once, click the "Browse" button to open the file
-	    browser. The browser will automatically direct you to the Invoices folder. Select the invoice
-	    that you would like the process, and then click "Process This Invoice".
+  - To use the app to process a single invoice at once, click the "Browse" button to open the file
+	browser. The browser will automatically direct you to the Invoices folder. Select the invoice
+	that you would like the process, and then click "Process This Invoice".
 
-	2 - To process all invoices in the Invoices folder, simply click the "Process All Invoices" button.
+  - To process all invoices in the Invoices folder, simply click the "Process All Invoices" button.
 
-5) The output of the processed invoice(s) can be read in the output window below the buttons, or in the
-   results file that can be viewed by pressing "View" -> "Results.txt".
+The output of the processed invoice(s) can be read in the output window below the buttons, or in the
+results file that can be viewed by pressing "View" -> "Results.txt".
 
-6) Repeat until all invoices are processed, and then click "Exit" to close the program.
+Repeat until all invoices are processed, and then click "Exit" to close the program.

--- a/scripts/installer.iss
+++ b/scripts/installer.iss
@@ -1,0 +1,97 @@
+; ###########################################################################
+; Inno Setup script for the Fishbowl Invoice Tool.
+;
+; Produces a per-user, no-UAC installer (FishbowlInvoiceTool_Setup.exe) from
+; the release payload that scripts/package_release.sh writes to
+; release/FishbowlInvoiceTool/. Designed so that UPGRADES replace the program
+; files (exe + user guide) while PRESERVING the customer's edited Configs/ and
+; any invoices they have dropped into Invoices/.
+;
+; The app (see source/constants.py) reads/writes logs/, data/, Configs/ and
+; Invoices/ RELATIVE TO ITS OWN EXE, so it is installed per-user into a
+; writable location ({localappdata}\Programs) rather than Program Files.
+;
+; Build (run from the repo root, after building the release payload):
+;   "C:\Program Files (x86)\Inno Setup 6\ISCC.exe" /DAppVersion=3.1.2 scripts\installer.iss
+;
+; AppVersion is passed in via /D so source/constants.py stays the single source
+; of truth; the #ifndef below provides a fallback for a bare manual compile.
+; ###########################################################################
+
+#define AppName "Fishbowl Invoice Tool"
+#ifndef AppVersion
+  #define AppVersion "0.0.0"
+#endif
+#define AppExeName "AutoInvoiceProc.exe"
+#define Publisher "Hammond Software"
+
+; Release payload produced by scripts/package_release.sh, relative to this .iss.
+#define SourceRoot "..\release\FishbowlInvoiceTool"
+
+; Optional installer icon. No .ico ships in the repo yet, so reference it only
+; if present; once scripts\assets\app.ico is added it is picked up automatically.
+#define IconFile "assets\app.ico"
+#define HaveIcon FileExists(AddBackslash(SourcePath) + IconFile)
+
+[Setup]
+; A stable AppId is what lets Inno recognize an existing install and upgrade it
+; in place. Do NOT change this GUID across versions.
+AppId={{4E1C7A2F-9B3D-4F6A-8C21-5D9E0B7A1F34}
+AppName={#AppName}
+AppVersion={#AppVersion}
+AppVerName={#AppName} {#AppVersion}
+AppPublisher={#Publisher}
+VersionInfoVersion={#AppVersion}
+VersionInfoCompany={#Publisher}
+VersionInfoDescription={#AppName} Setup
+
+; Per-user install, no admin prompt. {autopf} under lowest privileges resolves
+; to %LOCALAPPDATA%\Programs, which the app can freely write into at runtime.
+PrivilegesRequired=lowest
+DefaultDirName={autopf}\FishbowlInvoiceTool
+DefaultGroupName={#AppName}
+DisableProgramGroupPage=yes
+
+WizardStyle=modern
+Compression=lzma2/max
+SolidCompression=yes
+
+OutputDir=..\release
+OutputBaseFilename=FishbowlInvoiceTool_Setup
+UninstallDisplayName={#AppName}
+UninstallDisplayIcon={app}\{#AppExeName}
+#if HaveIcon
+SetupIconFile={#IconFile}
+#endif
+
+[Tasks]
+Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
+
+[Files]
+; Program files: always replaced on upgrade.
+Source: "{#SourceRoot}\{#AppExeName}"; DestDir: "{app}"; Flags: ignoreversion
+Source: "{#SourceRoot}\USER_GUIDE.txt"; DestDir: "{app}"; Flags: ignoreversion
+; Config files: ship defaults on a clean install, but never overwrite a
+; customer's edits on upgrade (onlyifdoesntexist) and never delete on
+; uninstall (uninsneveruninstall) -- this is the "preserveexisting" behavior.
+Source: "{#SourceRoot}\Configs\*"; DestDir: "{app}\Configs"; Flags: onlyifdoesntexist uninsneveruninstall recursesubdirs createallsubdirs
+; Invoices: preserve any the customer has added; tolerate an empty/missing
+; source folder (package_release.sh only populates it when run with `true`).
+Source: "{#SourceRoot}\Invoices\*"; DestDir: "{app}\Invoices"; Flags: onlyifdoesntexist uninsneveruninstall recursesubdirs createallsubdirs skipifsourcedoesntexist
+
+[Dirs]
+; Guarantee the app's writable folders exist even when shipped empty, and keep
+; the data-bearing ones on uninstall.
+Name: "{app}\logs"
+Name: "{app}\data"
+Name: "{app}\Configs"; Flags: uninsneveruninstall
+Name: "{app}\Invoices"; Flags: uninsneveruninstall
+
+[Icons]
+Name: "{group}\{#AppName}"; Filename: "{app}\{#AppExeName}"
+Name: "{group}\User Guide"; Filename: "{app}\USER_GUIDE.txt"
+Name: "{group}\Uninstall {#AppName}"; Filename: "{uninstallexe}"
+Name: "{autodesktop}\{#AppName}"; Filename: "{app}\{#AppExeName}"; Tasks: desktopicon
+
+[Run]
+Filename: "{app}\{#AppExeName}"; Description: "{cm:LaunchProgram,{#AppName}}"; Flags: nowait postinstall skipifsilent

--- a/scripts/package_release.sh
+++ b/scripts/package_release.sh
@@ -152,6 +152,38 @@ echo "Creating zip archive of the release..."
 cd "$ROOT_DIR/release"
 python -c "import shutil; shutil.make_archive('FishbowlInvoiceTool', 'zip', '.', 'FishbowlInvoiceTool')"
 
+# Additionally build a double-click Windows installer (FishbowlInvoiceTool_Setup.exe) from the
+# populated release/FishbowlInvoiceTool payload using Inno Setup (scripts/installer.iss). Inno's
+# ISCC.exe is Windows-only, so this is skipped on Linux and on Windows machines without Inno
+# installed -- the .zip above is the guaranteed artifact. CI installs Inno so the installer is
+# always produced there.
+if [[ "$OS_TYPE" == "MINGW"* || "$OS_TYPE" == "CYGWIN"* || "$OS_TYPE" == "MSYS"* ]]; then
+    # Locate the Inno Setup compiler: explicit $ISCC override, then the default install
+    # location, then anything named iscc on PATH.
+    ISCC_EXE="${ISCC:-}"
+    if [[ -z "$ISCC_EXE" && -x "/c/Program Files (x86)/Inno Setup 6/ISCC.exe" ]]; then
+        ISCC_EXE="/c/Program Files (x86)/Inno Setup 6/ISCC.exe"
+    fi
+    if [[ -z "$ISCC_EXE" ]] && command -v iscc >/dev/null 2>&1; then
+        ISCC_EXE="$(command -v iscc)"
+    fi
+
+    if [[ -z "$ISCC_EXE" ]]; then
+        echo "Inno Setup (ISCC.exe) not found; skipping installer build. The release zip is still available."
+        echo "Install Inno Setup 6 or set the ISCC environment variable to build FishbowlInvoiceTool_Setup.exe."
+    else
+        # Pass the in-app version (the single source of truth in source/constants.py) to the
+        # installer. Use //D (double slash) so Git Bash/MSYS does not path-mangle the
+        # /DAppVersion argument into a filesystem path.
+        VERSION="$(cd "$ROOT_DIR" && python -c 'from source import constants; print(constants.VERSION)')"
+        echo "Building installer with Inno Setup ($ISCC_EXE) for version $VERSION..."
+        "$ISCC_EXE" //DAppVersion="$VERSION" "$ROOT_DIR/scripts/installer.iss"
+        echo "Created installer: $ROOT_DIR/release/FishbowlInvoiceTool_Setup.exe"
+    fi
+else
+    echo "Non-Windows OS ($OS_TYPE); skipping Inno Setup installer build (ISCC.exe is Windows-only)."
+fi
+
 # Exit virtual environment on script exit
 echo "Deactivating virtual environment: $VIRTUAL_ENV"
 deactivate


### PR DESCRIPTION
## Summary

Merges the `release-automation` work into `main`. Two changes ahead of main:

- **Add Inno Setup installer script (#57)** — new `scripts/installer.iss` defining the Windows installer.
- **Build Inno Setup installer in release script and CI (#58)** — `scripts/package_release.sh` and `.github/workflows/release.yml` now build the installer as part of the release flow, plus USER_GUIDE/CLAUDE doc updates.

## Files changed
- `.github/workflows/release.yml`
- `CLAUDE.md`
- `USER_GUIDE.txt`
- `scripts/installer.iss`
- `scripts/package_release.sh`

## Test plan
- [ ] CI release workflow builds the installer successfully
- [ ] Generated installer runs and installs the app on Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)