### PR TITLE
Add UpdateChecker class (Part 4)

### DIFF
--- a/source/UpdateChecker.py
+++ b/source/UpdateChecker.py
@@ -1,0 +1,120 @@
+import json
+import urllib.error
+import urllib.request
+
+from source.constants import VERSION
+
+# GitHub releases API endpoint returning the single latest published release for
+# this repository. The JSON response exposes the release's `tag_name` (the
+# version) and `html_url` (the human-facing release page).
+GITHUB_LATEST_RELEASE_URL = (
+    "https://api.github.com/repos/averylhammond/FishbowlInvoiceTool/releases/latest"
+)
+
+# Cap how long the request may block so a slow or unreachable network can never
+# stall a caller (e.g. an update check run on application startup).
+REQUEST_TIMEOUT_SECONDS = 5
+
+# UpdateCheckResult is a plain data holder describing the outcome of comparing the
+# latest published release against the running application version.
+class UpdateCheckResult:
+
+    ###########################################################################
+    ###                  UpdateCheckResult -> __init__()                    ###
+    ###########################################################################
+    def __init__(self, update_available: bool, latest_version: str, release_url: str):
+        """
+        Initializes the UpdateCheckResult with the comparison outcome and the
+        details needed to point the user at the new release.
+
+        Args:
+            update_available (bool): True if the latest published release is
+                strictly newer than the running version.
+            latest_version (str): The latest release's version, normalized with any
+                leading "v" stripped (e.g. "3.1.0").
+            release_url (str): The URL of the latest release's page on GitHub.
+        """
+
+        self.update_available = update_available
+        self.latest_version = latest_version
+        self.release_url = release_url
+
+
+# UpdateChecker queries the GitHub releases API for the latest published release
+# and compares its version against the running application version, so the app can
+# tell the user when a newer build is available.
+class UpdateChecker:
+
+    ###########################################################################
+    ###                    UpdateChecker -> __init__()                      ###
+    ###########################################################################
+    def __init__(self, current_version: str = VERSION):
+        """
+        Initializes the UpdateChecker with the version to compare against.
+
+        Args:
+            current_version (str): The running application's version. Defaults to
+                the VERSION constant (the single source of truth) and is accepted as
+                an argument so callers and tests can compare against a known value.
+        """
+
+        self.current_version = current_version
+
+    ###########################################################################
+    ###                UpdateChecker -> check_for_update()                  ###
+    ###########################################################################
+    def check_for_update(self) -> UpdateCheckResult | None:
+        """
+        Fetches the latest published release from GitHub and compares it to the
+        running version.
+
+        The check fails silently: any network, HTTP, or parsing problem returns
+        None rather than raising, so a background check (e.g. on startup) never
+        interrupts the user just because they are offline or GitHub is unreachable.
+
+        Returns:
+            UpdateCheckResult | None: The comparison outcome and release details, or
+                None if the latest release could not be retrieved or parsed.
+        """
+
+        try:
+            with urllib.request.urlopen(
+                GITHUB_LATEST_RELEASE_URL, timeout=REQUEST_TIMEOUT_SECONDS
+            ) as response:
+                release = json.loads(response.read())
+
+            # Normalize the latest tag so a leading "v" (used inconsistently across
+            # release tags) never skews the comparison or the displayed version.
+            latest_version = release["tag_name"].lstrip("vV")
+            release_url = release["html_url"]
+
+            update_available = self._parse_version(latest_version) > self._parse_version(
+                self.current_version
+            )
+
+            return UpdateCheckResult(update_available, latest_version, release_url)
+        except (urllib.error.URLError, OSError, ValueError, KeyError):
+            # URLError/OSError: network or HTTP failure. ValueError: malformed JSON
+            # or a non-numeric version segment. KeyError: an unexpected response
+            # shape missing the fields we rely on.
+            return None
+
+    ###########################################################################
+    ###                  UpdateChecker -> _parse_version()                  ###
+    ###########################################################################
+    def _parse_version(self, version: str) -> tuple[int, ...]:
+        """
+        Parses a version string into a tuple of integers for semantic comparison.
+
+        Comparing the integer tuples (rather than the raw strings) keeps the
+        ordering numeric, so "3.10.0" correctly sorts after "3.9.0".
+
+        Args:
+            version (str): A dotted version string, optionally prefixed with "v"
+                (e.g. "v3.1.0" or "3.1.0").
+
+        Returns:
+            tuple[int, ...]: The version's numeric segments, e.g. (3, 1, 0).
+        """
+
+        return tuple(int(segment) for segment in version.lstrip("vV").split("."))

--- a/source/UpdateChecker.py
+++ b/source/UpdateChecker.py
@@ -54,8 +54,8 @@ class UpdateChecker:
 
         Args:
             current_version (str): The running application's version. Defaults to
-                the VERSION constant (the single source of truth) and is accepted as
-                an argument so callers and tests can compare against a known value.
+                the VERSION constant and is accepted as an argument so callers and
+                tests can compare against a known value.
         """
 
         self.current_version = current_version

--- a/tests/UpdateChecker_tests.py
+++ b/tests/UpdateChecker_tests.py
@@ -1,0 +1,189 @@
+import json
+import urllib.error
+from unittest.mock import patch, MagicMock
+
+from source.UpdateChecker import (
+    UpdateChecker,
+    GITHUB_LATEST_RELEASE_URL,
+    REQUEST_TIMEOUT_SECONDS,
+)
+
+
+###############################################################################
+###                     UpdateChecker -> Test Helpers                       ###
+###############################################################################
+def _release_response(tag_name: str, html_url: str = "https://example.com/release"):
+    """
+    Builds a mock object mimicking the context manager returned by
+    urllib.request.urlopen, whose read() yields a GitHub releases API JSON body.
+
+    Args:
+        tag_name (str): The release tag to embed under "tag_name".
+        html_url (str): The release page URL to embed under "html_url".
+
+    Returns:
+        unittest.mock.MagicMock: A mock suitable as urlopen's return value, usable
+            in a `with` statement.
+    """
+
+    body = json.dumps({"tag_name": tag_name, "html_url": html_url}).encode()
+
+    mock_response = MagicMock()
+    mock_response.read.return_value = body
+
+    # The object bound by `with urllib.request.urlopen(...) as response`
+    mock_context = MagicMock()
+    mock_context.__enter__.return_value = mock_response
+    return mock_context
+
+
+###############################################################################
+###               Tests UpdateChecker -> check_for_update()                 ###
+###############################################################################
+@patch("source.UpdateChecker.urllib.request.urlopen")
+def test_check_for_update_returns_result_when_newer_release_exists(mock_urlopen):
+    """
+    Verifies that a release newer than the running version yields a result flagged
+    as an available update, with the version and release URL parsed from the
+    response.
+
+    Args:
+        mock_urlopen (unittest.mock.MagicMock): Mocks urllib.request.urlopen
+    """
+
+    mock_urlopen.return_value = _release_response(
+        "v3.2.0", "https://example.com/v3.2.0"
+    )
+
+    result = UpdateChecker(current_version="3.1.2").check_for_update()
+
+    assert result.update_available is True
+    assert result.latest_version == "3.2.0"
+    assert result.release_url == "https://example.com/v3.2.0"
+
+
+@patch("source.UpdateChecker.urllib.request.urlopen")
+def test_check_for_update_no_update_when_versions_equal(mock_urlopen):
+    """
+    Verifies that a release matching the running version is not flagged as an
+    available update.
+
+    Args:
+        mock_urlopen (unittest.mock.MagicMock): Mocks urllib.request.urlopen
+    """
+
+    mock_urlopen.return_value = _release_response("v3.1.2")
+
+    result = UpdateChecker(current_version="3.1.2").check_for_update()
+
+    assert result.update_available is False
+    assert result.latest_version == "3.1.2"
+
+
+@patch("source.UpdateChecker.urllib.request.urlopen")
+def test_check_for_update_no_update_when_release_is_older(mock_urlopen):
+    """
+    Verifies that a release older than the running version is not flagged as an
+    available update.
+
+    Args:
+        mock_urlopen (unittest.mock.MagicMock): Mocks urllib.request.urlopen
+    """
+
+    mock_urlopen.return_value = _release_response("v3.1.0")
+
+    result = UpdateChecker(current_version="3.1.2").check_for_update()
+
+    assert result.update_available is False
+
+
+@patch("source.UpdateChecker.urllib.request.urlopen")
+def test_check_for_update_normalizes_v_prefix_inconsistency(mock_urlopen):
+    """
+    Verifies that the comparison still works when the release tag carries a "v"
+    prefix but the running version does not (the real-world tag format mismatch).
+
+    Args:
+        mock_urlopen (unittest.mock.MagicMock): Mocks urllib.request.urlopen
+    """
+
+    mock_urlopen.return_value = _release_response("v3.2.0")
+
+    result = UpdateChecker(current_version="3.1.2").check_for_update()
+
+    assert result.update_available is True
+    assert result.latest_version == "3.2.0"
+
+
+@patch("source.UpdateChecker.urllib.request.urlopen")
+def test_check_for_update_compares_versions_semantically_not_lexically(mock_urlopen):
+    """
+    Verifies that versions are compared numerically, so "3.10.0" is treated as newer
+    than "3.9.0" (a raw string comparison would get this backwards).
+
+    Args:
+        mock_urlopen (unittest.mock.MagicMock): Mocks urllib.request.urlopen
+    """
+
+    mock_urlopen.return_value = _release_response("v3.10.0")
+
+    result = UpdateChecker(current_version="3.9.0").check_for_update()
+
+    assert result.update_available is True
+
+
+@patch("source.UpdateChecker.urllib.request.urlopen")
+def test_check_for_update_requests_latest_release_url_with_timeout(mock_urlopen):
+    """
+    Verifies that the check queries the GitHub latest-release endpoint and caps the
+    request with the configured timeout.
+
+    Args:
+        mock_urlopen (unittest.mock.MagicMock): Mocks urllib.request.urlopen
+    """
+
+    mock_urlopen.return_value = _release_response("v3.1.2")
+
+    UpdateChecker(current_version="3.1.2").check_for_update()
+
+    mock_urlopen.assert_called_once_with(
+        GITHUB_LATEST_RELEASE_URL, timeout=REQUEST_TIMEOUT_SECONDS
+    )
+
+
+@patch("source.UpdateChecker.urllib.request.urlopen")
+def test_check_for_update_returns_none_on_network_error(mock_urlopen):
+    """
+    Verifies that a network failure is swallowed and reported as None rather than
+    raising, so a background check never interrupts the user.
+
+    Args:
+        mock_urlopen (unittest.mock.MagicMock): Mocks urllib.request.urlopen
+    """
+
+    mock_urlopen.side_effect = urllib.error.URLError("no network")
+
+    result = UpdateChecker(current_version="3.1.2").check_for_update()
+
+    assert result is None
+
+
+@patch("source.UpdateChecker.urllib.request.urlopen")
+def test_check_for_update_returns_none_on_malformed_response(mock_urlopen):
+    """
+    Verifies that a response body that is not valid JSON is swallowed and reported
+    as None.
+
+    Args:
+        mock_urlopen (unittest.mock.MagicMock): Mocks urllib.request.urlopen
+    """
+
+    mock_response = MagicMock()
+    mock_response.read.return_value = b"not json"
+    mock_context = MagicMock()
+    mock_context.__enter__.return_value = mock_response
+    mock_urlopen.return_value = mock_context
+
+    result = UpdateChecker(current_version="3.1.2").check_for_update()
+
+    assert result is None


### PR DESCRIPTION
Closes #59 (Part 4 of the in-app update-notification feature).

## What

Adds `source/UpdateChecker.py` — a self-contained, dependency-free class that queries the GitHub latest-release API, parses the latest tag, compares it to the `VERSION` constant, and returns an `UpdateCheckResult` (`update_available`, `latest_version`, `release_url`). Parts 5 (#60, run on startup) and 6 (#61, GUI notification) will consume it.

## Notes

- **Version-format mismatch handled.** `constants.py` stores `VERSION = "3.1.2"` (no prefix) while release tags are inconsistent (`v3.1.0`, older `2.1.0`). The checker strips a leading `v` and compares **integer tuples**, so the prefix never skews the result and `3.10.0` correctly sorts after `3.9.0`.
- **Stdlib-only** (`urllib.request` + `json`) — no new runtime dependency to bundle into the PyInstaller release.
- **Fails silently** — any network/HTTP/parse error returns `None`, so a background/startup check never nags an offline user with a popup. A 5s timeout prevents a hung connection from stalling startup.

## Tests

`tests/UpdateChecker_tests.py` — 8 tests patching `urlopen` with mocked GitHub API responses: newer/equal/older releases, `v`-prefix normalization, semantic-vs-lexical ordering, the request URL + timeout, and both silent-failure paths (network error, malformed JSON).

- New tests: 8 passed
- Full suite: 164 passed, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)