### PR TITLE
Run UpdateChecker on startup (Part 5)

### DIFF
--- a/source/InvoiceAppController.py
+++ b/source/InvoiceAppController.py
@@ -1,4 +1,5 @@
 # Import necessary classes from modules
+import threading
 from pathlib import Path
 
 from source.gui.InvoiceAppDisplay import InvoiceAppDisplay
@@ -6,6 +7,7 @@ from source.InvoiceAppFileIO import InvoiceAppFileIO
 from source.InvoiceProcessor import InvoiceProcessor
 from source.ArgumentProvider import ArgumentProvider
 from source.SettingsRepository import SettingsRepository
+from source.UpdateChecker import UpdateChecker
 from source.Invoice import Invoice
 from source.constants import (
     COST_CRITERIA_PATH,
@@ -101,8 +103,61 @@ class InvoiceAppController:
             # If in integration test mode, process all invoices directly without starting the GUI
             self.display.handle_process_all_invoices()
         else:
+            # Kick off a background check for a newer release before entering the
+            # GUI loop. Confined to this branch so integration-test mode performs no
+            # network I/O.
+            self._start_update_check()
+
             # Else, normally start the GUI application
             self.display.mainloop()
+
+    ###########################################################################
+    ###            InvoiceAppController -> _start_update_check()            ###
+    ###########################################################################
+    def _start_update_check(self):
+        """
+        Spawns a daemon thread that checks for a newer release on startup.
+
+        Running on a background thread keeps the GUI from blocking while waiting on
+        the GitHub API, and the daemon flag ensures a slow or stalled request can
+        never delay application shutdown.
+        """
+
+        threading.Thread(target=self._run_update_check, daemon=True).start()
+
+    ###########################################################################
+    ###             InvoiceAppController -> _run_update_check()             ###
+    ###########################################################################
+    def _run_update_check(self):
+        """
+        Worker-thread body for the startup update check.
+
+        Performs the (blocking, but silent-on-failure) update check off the GUI
+        thread, then hands the result back to the tkinter main thread via
+        display.after() so the GUI is only ever touched from the GUI thread.
+        """
+
+        result = UpdateChecker().check_for_update()
+        self.display.after(0, self._handle_update_result, result)
+
+    ###########################################################################
+    ###            InvoiceAppController -> _handle_update_result()          ###
+    ###########################################################################
+    def _handle_update_result(self, result):
+        """
+        Handles the outcome of the startup update check on the GUI thread.
+
+        Triggers the GUI response only when a strictly newer release exists. Does
+        nothing when the check failed silently (result is None) or the running
+        build is already up to date, so the user is never interrupted.
+
+        Args:
+            result (UpdateCheckResult | None): The comparison outcome from
+                UpdateChecker.check_for_update(), or None if the check failed.
+        """
+
+        if result and result.update_available:
+            self.display.show_update_available(result)
 
     ###########################################################################
     ###          InvoiceAppController -> handle_process_invoice()           ###

--- a/source/gui/InvoiceAppDisplay.py
+++ b/source/gui/InvoiceAppDisplay.py
@@ -574,6 +574,24 @@ class InvoiceAppDisplay(tk.Tk):
         messagebox.showerror(error_title, error_message)
 
     ###########################################################################
+    ###            InvoiceAppDisplay -> show_update_available()             ###
+    ###########################################################################
+    def show_update_available(self, result):
+        """
+        Notifies the user that a newer release is available.
+
+        Placeholder seam: the controller calls this on the GUI thread when its
+        startup update check finds a strictly newer release. The actual
+        notification UI is implemented in issue #61.
+
+        Args:
+            result (UpdateCheckResult): The outcome of the update check, exposing
+                the newer release's `latest_version` and `release_url`.
+        """
+
+        pass
+
+    ###########################################################################
     ###                 InvoiceAppDisplay -> handle_clear()                 ###
     ###########################################################################
     def handle_clear(self):

--- a/source/gui/InvoiceAppDisplay.py
+++ b/source/gui/InvoiceAppDisplay.py
@@ -581,8 +581,7 @@ class InvoiceAppDisplay(tk.Tk):
         Notifies the user that a newer release is available.
 
         Placeholder seam: the controller calls this on the GUI thread when its
-        startup update check finds a strictly newer release. The actual
-        notification UI is implemented in issue #61.
+        startup update check finds a strictly newer release.
 
         Args:
             result (UpdateCheckResult): The outcome of the update check, exposing

--- a/tests/InvoiceAppController_tests.py
+++ b/tests/InvoiceAppController_tests.py
@@ -183,11 +183,16 @@ def test_start_application_resets_files_and_starts_gui(controller):
 
     controller.arg_provider.integration_test_mode = False
 
-    controller.controller.start_application()
+    # Patch the update check so this test does not spawn a real background thread
+    with patch.object(controller.controller, "_start_update_check") as mock_start_update:
+        controller.controller.start_application()
 
     # Log files are reset before the application starts
     controller.file_io.reset_debug_file.assert_called_once_with()
     controller.file_io.reset_results_file.assert_called_once_with()
+
+    # The startup update check is kicked off before entering the GUI loop
+    mock_start_update.assert_called_once_with()
 
     # The GUI main loop is started, and invoices are not processed directly
     controller.display.mainloop.assert_called_once_with()
@@ -197,7 +202,8 @@ def test_start_application_resets_files_and_starts_gui(controller):
 def test_start_application_integration_test_mode_processes_all(controller):
     """
     Verifies that start_application processes all invoices directly (without the
-    GUI loop) when running in integration test mode.
+    GUI loop) when running in integration test mode, and never starts the update
+    check so no network I/O occurs in the headless CI run.
 
     Args:
         controller (pytest.fixture): Provides the controller and its mocks
@@ -205,11 +211,113 @@ def test_start_application_integration_test_mode_processes_all(controller):
 
     controller.arg_provider.integration_test_mode = True
 
-    controller.controller.start_application()
+    with patch.object(controller.controller, "_start_update_check") as mock_start_update:
+        controller.controller.start_application()
 
     # All invoices are processed directly, and the GUI loop is never entered
     controller.display.handle_process_all_invoices.assert_called_once_with()
     controller.display.mainloop.assert_not_called()
+
+    # The update check is never started in integration test mode
+    mock_start_update.assert_not_called()
+
+
+###############################################################################
+###          Tests InvoiceAppController -> _start_update_check()            ###
+###############################################################################
+def test_start_update_check_spawns_daemon_worker_thread(controller):
+    """
+    Verifies that _start_update_check launches the update worker on a started
+    daemon thread, so the check never blocks GUI startup or app shutdown.
+
+    Args:
+        controller (pytest.fixture): Provides the controller and its mocks
+    """
+
+    with patch("source.InvoiceAppController.threading.Thread") as mock_thread_cls:
+        controller.controller._start_update_check()
+
+    # The worker is wired as the thread target, marked daemon, and started
+    mock_thread_cls.assert_called_once_with(
+        target=controller.controller._run_update_check, daemon=True
+    )
+    mock_thread_cls.return_value.start.assert_called_once_with()
+
+
+###############################################################################
+###           Tests InvoiceAppController -> _run_update_check()             ###
+###############################################################################
+def test_run_update_check_schedules_result_on_gui_thread(controller):
+    """
+    Verifies that _run_update_check runs the UpdateChecker and marshals its result
+    back onto the tkinter thread via display.after().
+
+    Args:
+        controller (pytest.fixture): Provides the controller and its mocks
+    """
+
+    with patch("source.InvoiceAppController.UpdateChecker") as mock_update_checker_cls:
+        mock_result = mock_update_checker_cls.return_value.check_for_update.return_value
+
+        controller.controller._run_update_check()
+
+    # The update check is performed off the GUI thread
+    mock_update_checker_cls.assert_called_once_with()
+    mock_update_checker_cls.return_value.check_for_update.assert_called_once_with()
+
+    # The result is handed back to the GUI thread for handling
+    controller.display.after.assert_called_once_with(
+        0, controller.controller._handle_update_result, mock_result
+    )
+
+
+###############################################################################
+###          Tests InvoiceAppController -> _handle_update_result()          ###
+###############################################################################
+def test_handle_update_result_update_available_notifies_display(controller):
+    """
+    Verifies that _handle_update_result triggers the GUI response when a strictly
+    newer release is available.
+
+    Args:
+        controller (pytest.fixture): Provides the controller and its mocks
+    """
+
+    result = SimpleNamespace(update_available=True)
+
+    controller.controller._handle_update_result(result)
+
+    controller.display.show_update_available.assert_called_once_with(result)
+
+
+def test_handle_update_result_none_does_nothing(controller):
+    """
+    Verifies that _handle_update_result does nothing when the check failed silently
+    (result is None), so the user is never interrupted.
+
+    Args:
+        controller (pytest.fixture): Provides the controller and its mocks
+    """
+
+    controller.controller._handle_update_result(None)
+
+    controller.display.show_update_available.assert_not_called()
+
+
+def test_handle_update_result_up_to_date_does_nothing(controller):
+    """
+    Verifies that _handle_update_result does nothing when the running build is
+    already up to date (no newer release available).
+
+    Args:
+        controller (pytest.fixture): Provides the controller and its mocks
+    """
+
+    result = SimpleNamespace(update_available=False)
+
+    controller.controller._handle_update_result(result)
+
+    controller.display.show_update_available.assert_not_called()
 
 
 ###############################################################################


### PR DESCRIPTION
Closes #60.

## What
Wires the existing `UpdateChecker` (Part 4) into `InvoiceAppController` so the app checks for a newer release on startup.

- The check runs on a **daemon thread** kicked off from `start_application()` right before `mainloop()`, so it never blocks GUI startup — and the daemon flag means a slow/stalled request can't delay app shutdown.
- **Silent on any failure**: `check_for_update()` already returns `None` on any network/HTTP/parse error, so the user is never interrupted when offline or GitHub is unreachable.
- The worker result is marshaled back onto the tkinter thread via `display.after(0, ...)` (the app's existing deferral pattern, see `Tooltip`), and only when a *strictly newer* release exists does it trigger the GUI seam.
- **Integration-test mode skips the check entirely**, so the headless CI run does no network I/O.

## GUI seam
`InvoiceAppDisplay.show_update_available(result)` is added as a thin placeholder that the controller calls on the GUI thread. The actual notification UI is built in the next issue (#61).

## Tests
Extended `tests/InvoiceAppController_tests.py` (reusing the all-mocked `controller` fixture):
- update check starts in GUI mode, before `mainloop()`; never starts in integration-test mode
- `_start_update_check` spawns a started `daemon=True` thread targeting `_run_update_check`
- `_run_update_check` runs `UpdateChecker` and schedules `display.after(0, _handle_update_result, result)`
- `_handle_update_result` notifies the display only when `update_available` is true (no-op on `None` / up to date)

Full suite green: `169 passed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)