### PR TITLE
Add "Open User Guide" button to the Help menu (#70)

### DIFF
--- a/source/constants.py
+++ b/source/constants.py
@@ -27,6 +27,9 @@ COST_CRITERIA_PATH = CONFIGS_DIR / "Cost_Criteria.txt"
 # Database file holding persisted user settings (theme, font, etc.)
 SETTINGS_DB_PATH = DATA_DIR / "settings.db"
 
+# User guide shipped next to the executable; surfaced in-app via Help -> Open User Guide.
+USER_GUIDE_PATH = Path("USER_GUIDE.txt")
+
 # Keys under which user settings are persisted in the settings database. Shared
 # between the display (which reads/writes them) and any other consumer so the
 # two never drift apart.

--- a/source/gui/InvoiceAppDisplay.py
+++ b/source/gui/InvoiceAppDisplay.py
@@ -32,6 +32,7 @@ from source.constants import (
     COST_CRITERIA_PATH,
     RESULTS_LOG_PATH,
     DEBUG_LOG_PATH,
+    USER_GUIDE_PATH,
     SETTING_KEY_THEME,
     SETTING_KEY_FONT_FAMILY,
     SETTING_KEY_FONT_SIZE,
@@ -244,10 +245,14 @@ class InvoiceAppDisplay(tk.Tk):
         # Help dropdown
         #  -> About option to show the current application version
         #  -> Check for Updates option to manually check for a newer release
+        #  -> Open User Guide option to view the bundled USER_GUIDE.txt in-app
         self.help_menu = tk.Menu(self.menu_bar, tearoff=0)
         self.help_menu.add_command(label="About", command=self.handle_about)
         self.help_menu.add_command(
             label="Check for Updates", command=self.handle_check_for_updates
+        )
+        self.help_menu.add_command(
+            label="Open User Guide", command=self.handle_open_user_guide
         )
         self.menu_bar.add_cascade(label="Help", menu=self.help_menu)
 
@@ -579,6 +584,20 @@ class InvoiceAppDisplay(tk.Tk):
         self.check_for_updates_callback()
 
     ###########################################################################
+    ###            InvoiceAppDisplay -> handle_open_user_guide()            ###
+    ###########################################################################
+    def handle_open_user_guide(self):
+        """
+        On "Open User Guide" menu press, opens the bundled user guide in a native
+        read-only viewer window, themed to match the rest of the application.
+        """
+        self._open_readonly_file_viewer(
+            USER_GUIDE_PATH,
+            "User Guide",
+            f"User guide not found at: {USER_GUIDE_PATH}.",
+        )
+
+    ###########################################################################
     ###                  InvoiceAppDisplay -> show_popup()                  ###
     ###########################################################################
     def show_popup(self, title: str, message: str):
@@ -676,23 +695,27 @@ class InvoiceAppDisplay(tk.Tk):
         )
 
     ###########################################################################
-    ###               InvoiceAppDisplay -> _open_log_viewer()               ###
+    ###           InvoiceAppDisplay -> _open_readonly_file_viewer()         ###
     ###########################################################################
-    def _open_log_viewer(self, log_path: Path, title: str):
+    def _open_readonly_file_viewer(
+        self, file_path: Path, title: str, missing_message: str
+    ):
         """
-        Opens a native, read-only window showing the given log file if it exists.
-        Shows an error popup if the file has not been created yet.
+        Opens a native, read-only window showing the given text file if it exists.
+        Shows an error popup with the provided message if the file is not present.
 
         Args:
-            log_path (Path): The log file to open for viewing
+            file_path (Path): The text file to open for viewing
             title (str): The title to display on the viewer window
+            missing_message (str): The popup message shown when the file does not
+                exist
         """
-        if log_path.exists():
+        if file_path.exists():
             FileEditorWindow(
                 parent=self,
                 title=title,
-                file_path=log_path,
-                initial_text=self.read_file_callback(log_path),
+                file_path=file_path,
+                initial_text=self.read_file_callback(file_path),
                 theme=self.current_theme,
                 font_family=self.current_font_family,
                 font_size=self.current_font_size,
@@ -701,7 +724,7 @@ class InvoiceAppDisplay(tk.Tk):
         else:
             self.show_popup(
                 title="File Not Found",
-                message=f"Log not found at: {log_path}. Process an invoice to generate the log.",
+                message=missing_message,
             )
 
     ###########################################################################
@@ -739,7 +762,11 @@ class InvoiceAppDisplay(tk.Tk):
         Opens the results log file in a native read-only viewer window if it
         exists. Shows an error popup if the file has not been created yet.
         """
-        self._open_log_viewer(RESULTS_LOG_PATH, "Results Log")
+        self._open_readonly_file_viewer(
+            RESULTS_LOG_PATH,
+            "Results Log",
+            f"Log not found at: {RESULTS_LOG_PATH}. Process an invoice to generate the log.",
+        )
 
     ###########################################################################
     ###               InvoiceAppDisplay -> handle_debug_log()               ###
@@ -749,7 +776,11 @@ class InvoiceAppDisplay(tk.Tk):
         Opens the debug log file in a native read-only viewer window if it exists.
         Shows an error popup if the file has not been created yet.
         """
-        self._open_log_viewer(DEBUG_LOG_PATH, "Debug Log")
+        self._open_readonly_file_viewer(
+            DEBUG_LOG_PATH,
+            "Debug Log",
+            f"Log not found at: {DEBUG_LOG_PATH}. Process an invoice to generate the log.",
+        )
 
     ###########################################################################
     ###                 InvoiceAppDisplay -> apply_theme()                  ###

--- a/tests/InvoiceAppDisplay_tests.py
+++ b/tests/InvoiceAppDisplay_tests.py
@@ -896,6 +896,63 @@ def test_handle_debug_log_missing_shows_error(
 
 
 ###############################################################################
+###           Tests InvoiceAppDisplay -> handle_open_user_guide()           ###
+###############################################################################
+@patch("source.gui.InvoiceAppDisplay.FileEditorWindow")
+@patch("source.gui.InvoiceAppDisplay.USER_GUIDE_PATH")
+def test_handle_open_user_guide_opens_when_present(
+    mock_guide_path, mock_window_cls, display
+):
+    """
+    Verifies that handle_open_user_guide opens a read-only viewer window titled
+    "User Guide" showing the bundled guide file when it exists.
+
+    Args:
+        mock_guide_path (unittest.mock.MagicMock): Mocks the USER_GUIDE_PATH constant
+        mock_window_cls (unittest.mock.MagicMock): Mocks the FileEditorWindow class
+        display (pytest.fixture): Provides the display and its mocks
+    """
+
+    # The user guide file exists on disk
+    mock_guide_path.exists.return_value = True
+
+    display.display.handle_open_user_guide()
+
+    # The guide is read and opened in a read-only viewer window titled "User Guide"
+    display.read_file_callback.assert_called_once_with(mock_guide_path)
+    assert mock_window_cls.call_args.kwargs["file_path"] is mock_guide_path
+    assert mock_window_cls.call_args.kwargs["title"] == "User Guide"
+    assert mock_window_cls.call_args.kwargs["editable"] is False
+
+
+@patch.object(InvoiceAppDisplay, "show_popup")
+@patch("source.gui.InvoiceAppDisplay.FileEditorWindow")
+@patch("source.gui.InvoiceAppDisplay.USER_GUIDE_PATH")
+def test_handle_open_user_guide_missing_shows_error(
+    mock_guide_path, mock_window_cls, mock_show_popup, display
+):
+    """
+    Verifies that handle_open_user_guide shows an error popup (and opens nothing)
+    when the bundled user guide file is not present.
+
+    Args:
+        mock_guide_path (unittest.mock.MagicMock): Mocks the USER_GUIDE_PATH constant
+        mock_window_cls (unittest.mock.MagicMock): Mocks the FileEditorWindow class
+        mock_show_popup (unittest.mock.MagicMock): Mocks show_popup
+        display (pytest.fixture): Provides the display and its mocks
+    """
+
+    # The user guide file is missing
+    mock_guide_path.exists.return_value = False
+
+    display.display.handle_open_user_guide()
+
+    # An error popup is shown and no window is opened
+    mock_show_popup.assert_called_once()
+    mock_window_cls.assert_not_called()
+
+
+###############################################################################
 ###                Tests InvoiceAppDisplay -> apply_theme()                 ###
 ###############################################################################
 def test_apply_theme_updates_state_and_widgets(display):


### PR DESCRIPTION
Closes #70.

## What

Adds an **Open User Guide** entry to the Help menu that opens the bundled `USER_GUIDE.txt` in a native, read-only, themed viewer window (centered over the main window, styled with the active theme/font, with a Close button).

## How

- **`source/constants.py`** — add `USER_GUIDE_PATH = Path("USER_GUIDE.txt")`.
- **`source/gui/InvoiceAppDisplay.py`**
  - Add the **Open User Guide** command to the Help menu and a `handle_open_user_guide` handler.
  - Generalize the existing read-only viewer helper `_open_log_viewer` → `_open_readonly_file_viewer(file_path, title, missing_message)`, and route the guide, results log, and debug log through it.
- **`tests/InvoiceAppDisplay_tests.py`** — add tests for opening the guide read-only when present and showing an error popup when missing.

## Note on the approach

The issue suggested creating a new `ThemedSubwindow` subclass. Instead this **reuses the existing `FileEditorWindow(editable=False)`** — the same read-only viewer the View menu uses for logs — to avoid a near-duplicate class, consistent with the DRY/SRP guidance in `CLAUDE.md`. This is a deliberate deviation from the issue's literal wording.

No packaging change needed: `USER_GUIDE.txt` is already bundled by `scripts/package_release.sh` and `scripts/installer.iss`.

## Testing

- `pytest tests/*` — all 189 pass.
- Manual: `python main.py` → **Help → Open User Guide** opens the themed, scrollable, read-only guide window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)