### PR TITLE
Open the user guide in a larger window

### DIFF
--- a/source/gui/FileEditorWindow.py
+++ b/source/gui/FileEditorWindow.py
@@ -29,6 +29,8 @@ class FileEditorWindow(ThemedSubwindow):
         font_size: int,
         editable: bool = True,
         save_callback: Callable[[Path, str], None] | None = None,
+        text_width: int | None = None,
+        text_height: int | None = None,
     ):
         """
         Initializes the FileEditorWindow object
@@ -49,6 +51,12 @@ class FileEditorWindow(ThemedSubwindow):
             save_callback (Callable[[Path, str], None] | None): Called with the
                 file path and the edited contents when the user saves. Required
                 when editable is True; ignored when editable is False
+            text_width (int | None): Width of the text box in character cells.
+                When None, tkinter's default width is used (suitable for the
+                config/log files). Larger files (e.g. the user guide) can request
+                a wider box for easier reading
+            text_height (int | None): Height of the text box in character cells.
+                When None, tkinter's default height is used
         """
 
         super().__init__(parent, title, theme, font_family, font_size)
@@ -61,6 +69,10 @@ class FileEditorWindow(ThemedSubwindow):
 
         # Callback used to persist edits when the user saves
         self.save_callback = save_callback
+
+        # Text box dimensions in character cells; None uses tkinter's defaults
+        self.text_width = text_width
+        self.text_height = text_height
 
         # Tkinter Widgets
         # fmt:off
@@ -93,6 +105,14 @@ class FileEditorWindow(ThemedSubwindow):
         # in the config files stay aligned, the way they appear in a text editor.
         # TODO: Remove use of MONOSPACE once the format of the config files can be
         #       changed, and the commment header in the file does not cause alignment issues
+        # Only pass width/height when supplied so tkinter's defaults are kept for
+        # the config/log files; larger files (the user guide) can request a bigger box
+        size_kwargs = {}
+        if self.text_width is not None:
+            size_kwargs["width"] = self.text_width
+        if self.text_height is not None:
+            size_kwargs["height"] = self.text_height
+
         self.text_box = scrolledtext.ScrolledText(
             self,
             wrap="word",
@@ -101,6 +121,7 @@ class FileEditorWindow(ThemedSubwindow):
             fg=self.theme.fg_text,
             insertbackground=self.theme.fg_text,
             relief="flat",
+            **size_kwargs,
         )
         self.text_box.insert(tk.END, initial_text)
         self.text_box.pack(padx=20, pady=(20, 10), fill="both", expand=True)

--- a/source/gui/InvoiceAppDisplay.py
+++ b/source/gui/InvoiceAppDisplay.py
@@ -591,10 +591,14 @@ class InvoiceAppDisplay(tk.Tk):
         On "Open User Guide" menu press, opens the bundled user guide in a native
         read-only viewer window, themed to match the rest of the application.
         """
+        # The user guide is longer than the config/log files, so open it in a
+        # larger window so more of the text is visible without scrolling
         self._open_readonly_file_viewer(
             USER_GUIDE_PATH,
             "User Guide",
             f"User guide not found at: {USER_GUIDE_PATH}.",
+            text_width=100,
+            text_height=35,
         )
 
     ###########################################################################
@@ -698,7 +702,12 @@ class InvoiceAppDisplay(tk.Tk):
     ###           InvoiceAppDisplay -> _open_readonly_file_viewer()         ###
     ###########################################################################
     def _open_readonly_file_viewer(
-        self, file_path: Path, title: str, missing_message: str
+        self,
+        file_path: Path,
+        title: str,
+        missing_message: str,
+        text_width: int | None = None,
+        text_height: int | None = None,
     ):
         """
         Opens a native, read-only window showing the given text file if it exists.
@@ -709,6 +718,11 @@ class InvoiceAppDisplay(tk.Tk):
             title (str): The title to display on the viewer window
             missing_message (str): The popup message shown when the file does not
                 exist
+            text_width (int | None): Width of the text box in character cells, or
+                None to use the default size (used to enlarge the viewer for
+                longer files such as the user guide)
+            text_height (int | None): Height of the text box in character cells, or
+                None to use the default size
         """
         if file_path.exists():
             FileEditorWindow(
@@ -720,6 +734,8 @@ class InvoiceAppDisplay(tk.Tk):
                 font_family=self.current_font_family,
                 font_size=self.current_font_size,
                 editable=False,
+                text_width=text_width,
+                text_height=text_height,
             )
         else:
             self.show_popup(

--- a/tests/FileEditorWindow_tests.py
+++ b/tests/FileEditorWindow_tests.py
@@ -23,7 +23,13 @@ def _distinct_widget(*_args, **_kwargs):
     return MagicMock()
 
 
-def _build_window(editable: bool, save_callback=None, initial_text: str = "file body"):
+def _build_window(
+    editable: bool,
+    save_callback=None,
+    initial_text: str = "file body",
+    text_width=None,
+    text_height=None,
+):
     """
     Builds a FileEditorWindow in complete isolation from tkinter: the real
     Toplevel.__init__ is neutralized, the inherited methods the constructor calls
@@ -34,10 +40,13 @@ def _build_window(editable: bool, save_callback=None, initial_text: str = "file 
         editable (bool): Whether to build the window in editable or read-only mode
         save_callback (callable | None): The save callback to pass through
         initial_text (str): The initial text the window displays
+        text_width (int | None): The text box width (in character cells) to pass
+        text_height (int | None): The text box height (in character cells) to pass
 
     Returns:
-        types.SimpleNamespace: Holds the constructed window (`window`) and the
-            file path it was bound to (`file_path`).
+        types.SimpleNamespace: Holds the constructed window (`window`), the file
+            path it was bound to (`file_path`), and the patched ScrolledText class
+            (`text_cls`) so tests can assert how the text box was constructed.
     """
 
     file_path = Path("Configs/Sales_Reps.txt")
@@ -52,7 +61,7 @@ def _build_window(editable: bool, save_callback=None, initial_text: str = "file 
         patch(
             "source.gui.FileEditorWindow.scrolledtext.ScrolledText",
             side_effect=_distinct_widget,
-        ),
+        ) as text_cls,
     ):
 
         window = FileEditorWindow(
@@ -65,9 +74,11 @@ def _build_window(editable: bool, save_callback=None, initial_text: str = "file 
             font_size=DEFAULT_FONT_SIZE,
             editable=editable,
             save_callback=save_callback,
+            text_width=text_width,
+            text_height=text_height,
         )
 
-    return SimpleNamespace(window=window, file_path=file_path)
+    return SimpleNamespace(window=window, file_path=file_path, text_cls=text_cls)
 
 
 ###############################################################################
@@ -112,6 +123,32 @@ def test_readonly_window_disables_text_and_has_only_close_button():
     assert built.window.save_button is None
     assert built.window.close_button is not None
     built.window.close_button.grid.assert_called_once_with(row=0, column=0, padx=10)
+
+
+def test_text_box_uses_default_size_when_unspecified():
+    """
+    Verifies that no width/height is passed to the text box when none is requested,
+    so tkinter's default size is used for the config/log files.
+    """
+
+    built = _build_window(editable=False)
+
+    text_kwargs = built.text_cls.call_args.kwargs
+    assert "width" not in text_kwargs
+    assert "height" not in text_kwargs
+
+
+def test_text_box_uses_requested_size():
+    """
+    Verifies that a requested width/height is passed through to the text box so
+    longer files (e.g. the user guide) can be shown in a larger window.
+    """
+
+    built = _build_window(editable=False, text_width=100, text_height=35)
+
+    text_kwargs = built.text_cls.call_args.kwargs
+    assert text_kwargs["width"] == 100
+    assert text_kwargs["height"] == 35
 
 
 def test_close_button_is_wired_to_destroy():

--- a/tests/InvoiceAppDisplay_tests.py
+++ b/tests/InvoiceAppDisplay_tests.py
@@ -918,11 +918,14 @@ def test_handle_open_user_guide_opens_when_present(
 
     display.display.handle_open_user_guide()
 
-    # The guide is read and opened in a read-only viewer window titled "User Guide"
+    # The guide is read and opened in a read-only viewer window titled "User Guide",
+    # sized larger than the default since the guide is longer than the other files
     display.read_file_callback.assert_called_once_with(mock_guide_path)
     assert mock_window_cls.call_args.kwargs["file_path"] is mock_guide_path
     assert mock_window_cls.call_args.kwargs["title"] == "User Guide"
     assert mock_window_cls.call_args.kwargs["editable"] is False
+    assert mock_window_cls.call_args.kwargs["text_width"] == 100
+    assert mock_window_cls.call_args.kwargs["text_height"] == 35
 
 
 @patch.object(InvoiceAppDisplay, "show_popup")


### PR DESCRIPTION
Follow-up to #76. The user guide is longer than the config/log files, so it's now shown in a bigger viewer window for easier reading.

## How

- **`source/gui/FileEditorWindow.py`** — add optional `text_width` / `text_height` parameters (in character cells). They default to `None`, which keeps tkinter's default size for the config and log viewers (unchanged behavior).
- **`source/gui/InvoiceAppDisplay.py`** — thread the size through `_open_readonly_file_viewer`; `handle_open_user_guide` requests a 100×35 character text box.

## Testing

- `pytest tests/*` — all pass.
- Added `FileEditorWindow` tests covering both the default (no size passed) and the requested-size cases, and extended the user-guide handler test to assert the larger dimensions.
- Manual: **Help → Open User Guide** now opens a noticeably larger, scrollable window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)