### PR TITLE
Rev app version to 4.0.1

### DIFF
--- a/source/constants.py
+++ b/source/constants.py
@@ -5,7 +5,7 @@ DECIMAL_ZERO = Decimal("0.00")
 
 # Current application version. Single source of truth for the version, kept
 # consistent with application releases and surfaced to the user via Help -> About.
-VERSION = "4.0.0"
+VERSION = "4.0.1"
 
 # Application file paths, relative to the executable's current working directory.
 


### PR DESCRIPTION
Bumps the application version from `4.0.0` to `4.0.1` in `source/constants.py`, the single source of truth surfaced to the user via Help → About and used by the release tag verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)