### PR TITLE
Close app after launching update download

### DIFF
--- a/source/gui/InvoiceAppDisplay.py
+++ b/source/gui/InvoiceAppDisplay.py
@@ -636,8 +636,8 @@ class InvoiceAppDisplay(tk.Tk):
     def show_update_available(self, result):
         """
         Notifies the user that a newer release is available by opening a themed
-        popup showing the available version, with a Download button linking to the
-        release page and a Close button.
+        popup showing the available version, with an "Exit and Update" button that
+        opens the release page and closes the app, and a Close button.
 
         The controller calls this on the GUI thread when an update check (on
         startup or triggered manually from the Help menu) finds a strictly newer
@@ -658,6 +658,9 @@ class InvoiceAppDisplay(tk.Tk):
             title="Update Available",
             latest_version=result.latest_version,
             release_url=result.release_url,
+            # self is the root tk.Tk, so destroy() exits the whole app, releasing
+            # the executable's file lock so the installer can replace it
+            close_app_callback=self.destroy,
             theme=self.current_theme,
             font_family=self.current_font_family,
             font_size=self.current_font_size,

--- a/source/gui/UpdateWindow.py
+++ b/source/gui/UpdateWindow.py
@@ -1,16 +1,24 @@
 import tkinter as tk
 import webbrowser
+from typing import Callable
 
 from source.gui.color_theme import Theme
 from source.gui.ThemedSubwindow import ThemedSubwindow
 
 
+# Delay, in milliseconds, between opening the release page and closing the
+# application. The app must exit so the Windows installer can replace the running
+# executable (a locked .exe cannot be overwritten); the brief delay lets the
+# browser come to the foreground before the app disappears.
+CLOSE_DELAY_MS = 3000
+
+
 # UpdateWindow class to notify the user that a newer release is available. It is a
-# small window showing the available version alongside a Download button that opens
-# the release's GitHub page in the user's browser, plus a Close button to dismiss
-# it. Like the other themed subwindows it snapshots the active theme/font at open
-# time and centers itself over the main application window (both handled by
-# ThemedSubwindow).
+# small window showing the available version alongside an "Exit and Update" button
+# that opens the release's GitHub page in the user's browser and then closes the
+# application, plus a Close button to dismiss it without updating. Like the other
+# themed subwindows it snapshots the active theme/font at open time and centers
+# itself over the main application window (both handled by ThemedSubwindow).
 class UpdateWindow(ThemedSubwindow):
 
     ###########################################################################
@@ -22,6 +30,7 @@ class UpdateWindow(ThemedSubwindow):
         title: str,
         latest_version: str,
         release_url: str,
+        close_app_callback: Callable[[], None],
         theme: Theme,
         font_family: str,
         font_size: int,
@@ -34,7 +43,10 @@ class UpdateWindow(ThemedSubwindow):
             title (str): Title of the update window
             latest_version (str): The newer release's version to display
             release_url (str): The URL of the release's page on GitHub, opened when
-                the Download button is pressed
+                the "Exit and Update" button is pressed
+            close_app_callback (Callable[[], None]): Closes the whole application,
+                invoked a few seconds after "Exit and Update" is pressed so the
+                installer can replace the running executable
             theme (Theme): The color theme to style the window with, snapshotted
                 at open time
             font_family (str): The font family to display the text with
@@ -47,11 +59,17 @@ class UpdateWindow(ThemedSubwindow):
         self.latest_version = latest_version
         self.release_url = release_url
 
+        # Closes the application once the user has been sent to the download page
+        self.close_app_callback = close_app_callback
+
+        # Guards against repeated clicks stacking multiple close timers
+        self._closing = False
+
         # Tkinter Widgets
         # fmt:off
-        self.info_label:      tk.Label  | None = None
-        self.download_button: tk.Button | None = None
-        self.close_button:    tk.Button | None = None
+        self.info_label:    tk.Label  | None = None
+        self.update_button: tk.Button | None = None
+        self.close_button:  tk.Button | None = None
         # fmt:on
 
         self.build_widgets()
@@ -65,9 +83,9 @@ class UpdateWindow(ThemedSubwindow):
     ###########################################################################
     def build_widgets(self):
         """
-        Creates the label announcing the available version, the Download button
-        that opens the release page, and the Close button used to dismiss the
-        window
+        Creates the label announcing the available version, the "Exit and Update"
+        button that opens the release page and closes the app, and the Close button
+        used to dismiss the window without updating
         """
 
         # Label announcing that a newer release is available
@@ -80,10 +98,11 @@ class UpdateWindow(ThemedSubwindow):
         )
         self.info_label.pack(padx=20, pady=(20, 10))
 
-        # Download button to open the release page in the user's browser
-        self.download_button = tk.Button(
+        # "Exit and Update" button to open the release page in the user's browser
+        # and then close the application so the installer can replace the exe
+        self.update_button = tk.Button(
             self,
-            text="Download",
+            text="Exit and Update",
             command=self._open_release_page,
             bg=self.theme.button_bg,
             fg=self.theme.button_fg,
@@ -92,7 +111,7 @@ class UpdateWindow(ThemedSubwindow):
             relief="flat",
             font=(self.font_family, self.font_size, "bold"),
         )
-        self.download_button.pack(pady=(0, 10))
+        self.update_button.pack(pady=(0, 10))
 
         # Close button to dismiss the window
         self.close_button = tk.Button(
@@ -114,8 +133,28 @@ class UpdateWindow(ThemedSubwindow):
     def _open_release_page(self):
         """
         Opens the release's GitHub page in the user's default browser so they can
-        download the newer version. The window stays open so the user can return
-        to it; Close dismisses it.
+        download the newer version, then closes the application after a short delay.
+
+        The app must exit so the downloaded installer can overwrite the running
+        executable, which Windows keeps file-locked while the process is alive;
+        leaving it open is what makes the installer hang trying to close it. The
+        delay (CLOSE_DELAY_MS) lets the browser surface before the app disappears.
+        Repeated clicks are ignored once a close has been scheduled.
         """
 
+        if self._closing:
+            return
+        self._closing = True
+
         webbrowser.open(self.release_url)
+
+        # Tell the user what is about to happen and prevent further interaction
+        # with a window that is on its way out
+        if self.info_label is not None:
+            self.info_label.config(text="Closing to install update…")
+        if self.update_button is not None:
+            self.update_button.config(state=tk.DISABLED)
+
+        # Close the whole application (not just this window) once the user has been
+        # sent to the download page, so the installer can replace the running exe
+        self.after(CLOSE_DELAY_MS, self.close_app_callback)

--- a/tests/InvoiceAppDisplay_tests.py
+++ b/tests/InvoiceAppDisplay_tests.py
@@ -752,12 +752,15 @@ def test_show_update_available_opens_window(mock_window_cls, display):
 
     display.display.show_update_available(result)
 
-    # The update window is opened with the result's details and active theme/font
+    # The update window is opened with the result's details and active theme/font,
+    # and is given the root window's destroy as the app-close callback so the app
+    # exits (releasing the exe lock) after the user is sent to the download page
     mock_window_cls.assert_called_once_with(
         parent=display.display,
         title="Update Available",
         latest_version="9.9.9",
         release_url="https://example.com/release",
+        close_app_callback=display.display.destroy,
         theme=display.display.current_theme,
         font_family=display.display.current_font_family,
         font_size=display.display.current_font_size,

--- a/tests/UpdateWindow_tests.py
+++ b/tests/UpdateWindow_tests.py
@@ -2,7 +2,7 @@ import tkinter as tk
 from types import SimpleNamespace
 from unittest.mock import patch, MagicMock
 
-from source.gui.UpdateWindow import UpdateWindow
+from source.gui.UpdateWindow import UpdateWindow, CLOSE_DELAY_MS
 from source.gui.color_theme import DARK
 from source.gui.font_settings import DEFAULT_FONT_FAMILY, DEFAULT_FONT_SIZE
 
@@ -14,14 +14,18 @@ def _distinct_widget(*_args, **_kwargs):
     """
     Side effect for patched tkinter widget classes that returns a fresh
     MagicMock for every constructed widget, so each widget attribute on the
-    window (e.g. info_label vs. download_button vs. close_button) is a distinct
+    window (e.g. info_label vs. update_button vs. close_button) is a distinct
     mock that can be asserted on independently.
     """
 
     return MagicMock()
 
 
-def _build_window(latest_version="9.9.9", release_url="https://example.com/release"):
+def _build_window(
+    latest_version="9.9.9",
+    release_url="https://example.com/release",
+    close_app_callback=None,
+):
     """
     Builds an UpdateWindow in complete isolation from tkinter: the real
     Toplevel.__init__ is neutralized, the inherited methods the constructor calls
@@ -31,12 +35,17 @@ def _build_window(latest_version="9.9.9", release_url="https://example.com/relea
     Args:
         latest_version (str): The available version to build the window with
         release_url (str): The release URL to build the window with
+        close_app_callback (Callable | None): The app-close callback to build the
+            window with; a fresh MagicMock is used when not supplied
 
     Returns:
-        types.SimpleNamespace: Holds the constructed window (`window`) and the
-            patched tk.Label/tk.Button classes (`label_cls`, `button_cls`) so
-            tests can assert on how each widget was constructed.
+        types.SimpleNamespace: Holds the constructed window (`window`), the patched
+            tk.Label/tk.Button classes (`label_cls`, `button_cls`), and the
+            close-app callback (`close_app_callback`) so tests can assert on how
+            each widget was constructed and that the app is closed.
     """
+
+    close_app_callback = close_app_callback or MagicMock()
 
     with (
         patch.object(tk.Toplevel, "__init__", return_value=None),
@@ -56,12 +65,18 @@ def _build_window(latest_version="9.9.9", release_url="https://example.com/relea
             title="Update Available",
             latest_version=latest_version,
             release_url=release_url,
+            close_app_callback=close_app_callback,
             theme=DARK,
             font_family=DEFAULT_FONT_FAMILY,
             font_size=DEFAULT_FONT_SIZE,
         )
 
-    return SimpleNamespace(window=window, label_cls=label_cls, button_cls=button_cls)
+    return SimpleNamespace(
+        window=window,
+        label_cls=label_cls,
+        button_cls=button_cls,
+        close_app_callback=close_app_callback,
+    )
 
 
 ###############################################################################
@@ -69,14 +84,14 @@ def _build_window(latest_version="9.9.9", release_url="https://example.com/relea
 ###############################################################################
 def test_build_widgets_creates_label_and_buttons():
     """
-    Verifies that build_widgets constructs the info label, the Download button,
-    and the Close button, storing each on the window.
+    Verifies that build_widgets constructs the info label, the "Exit and Update"
+    button, and the Close button, storing each on the window.
     """
 
     built = _build_window()
 
     assert built.window.info_label is not None
-    assert built.window.download_button is not None
+    assert built.window.update_button is not None
     assert built.window.close_button is not None
 
 
@@ -125,24 +140,24 @@ def test_close_button_is_wired_to_destroy():
 
     built = _build_window()
 
-    # The Close button is the second button constructed (after Download)
+    # The Close button is the second button constructed (after "Exit and Update")
     close_kwargs = built.button_cls.call_args_list[1].kwargs
     assert close_kwargs["text"] == "Close"
     assert close_kwargs["command"] == built.window.destroy
 
 
-def test_download_button_is_wired_to_open_release_page():
+def test_update_button_is_wired_to_open_release_page():
     """
-    Verifies that the Download button's command opens the release page, so
+    Verifies that the "Exit and Update" button's command opens the release page, so
     pressing it sends the user to the release on GitHub.
     """
 
     built = _build_window()
 
-    # The Download button is the first button constructed
-    download_kwargs = built.button_cls.call_args_list[0].kwargs
-    assert download_kwargs["text"] == "Download"
-    assert download_kwargs["command"] == built.window._open_release_page
+    # The "Exit and Update" button is the first button constructed
+    update_kwargs = built.button_cls.call_args_list[0].kwargs
+    assert update_kwargs["text"] == "Exit and Update"
+    assert update_kwargs["command"] == built.window._open_release_page
 
 
 ###############################################################################
@@ -154,8 +169,64 @@ def test_open_release_page_opens_url_in_browser():
     """
 
     built = _build_window(release_url="https://example.com/release")
+    # after() would otherwise hit the real Tcl interpreter, which the isolated
+    # window has none of; the scheduling itself is asserted in a dedicated test
+    built.window.after = MagicMock()
 
     with patch("source.gui.UpdateWindow.webbrowser.open") as mock_open:
         built.window._open_release_page()
 
     mock_open.assert_called_once_with("https://example.com/release")
+
+
+def test_open_release_page_schedules_app_close_after_delay():
+    """
+    Verifies that _open_release_page schedules the application to close after the
+    configured delay, so the installer can replace the running executable.
+    """
+
+    built = _build_window()
+    built.window.after = MagicMock()
+
+    with patch("source.gui.UpdateWindow.webbrowser.open"):
+        built.window._open_release_page()
+
+    built.window.after.assert_called_once_with(
+        CLOSE_DELAY_MS, built.close_app_callback
+    )
+
+
+def test_open_release_page_ignores_repeat_clicks():
+    """
+    Verifies that clicking "Exit and Update" again after a close has been scheduled
+    does not open a second browser tab or stack a second close timer.
+    """
+
+    built = _build_window()
+    built.window.after = MagicMock()
+
+    with patch("source.gui.UpdateWindow.webbrowser.open") as mock_open:
+        built.window._open_release_page()
+        built.window._open_release_page()
+
+    # The browser is opened and the close scheduled exactly once despite two clicks
+    mock_open.assert_called_once()
+    built.window.after.assert_called_once()
+
+
+def test_open_release_page_disables_button_and_updates_label():
+    """
+    Verifies that _open_release_page tells the user the app is closing and disables
+    the "Exit and Update" button so an outgoing window cannot be re-triggered.
+    """
+
+    built = _build_window()
+    built.window.after = MagicMock()
+
+    with patch("source.gui.UpdateWindow.webbrowser.open"):
+        built.window._open_release_page()
+
+    built.window.info_label.config.assert_called_once_with(
+        text="Closing to install update…"
+    )
+    built.window.update_button.config.assert_called_once_with(state=tk.DISABLED)


### PR DESCRIPTION
## Summary
The update-available popup now relabels its primary button from **"Download"** to **"Exit and Update"**. Clicking it opens the release page in the browser and then closes the whole application after a short delay.

### Why
On Windows the running `.exe` stays file-locked while the process is alive, so leaving the app open made the downloaded installer hang trying to replace it. Closing the app releases the lock so the installer can overwrite the executable.

### Changes
- **`UpdateWindow`**: add a `close_app_callback`, a `CLOSE_DELAY_MS` constant, and a repeat-click guard; rename the `download_button` attribute to `update_button`; on click, update the label to "Closing to install update…", disable the button, and schedule the app close.
- **`InvoiceAppDisplay`**: pass `self.destroy` (root `tk.Tk`) as the close callback so the whole app exits.
- **Tests**: updated for the new label/attribute and added coverage for the close-on-click behavior (schedules close once, ignores repeat clicks, updates label/disables button).

## Test plan
- `pytest tests/*` — all 194 tests pass.
- Manual GUI smoke test: trigger the update popup, confirm the button reads "Exit and Update", that clicking it opens the release page, the label switches to the closing message, and the app closes after ~3s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)