### PR TITLE
Bump version to 4.0.2

### DIFF
--- a/source/constants.py
+++ b/source/constants.py
@@ -5,7 +5,7 @@ DECIMAL_ZERO = Decimal("0.00")
 
 # Current application version. Single source of truth for the version, kept
 # consistent with application releases and surfaced to the user via Help -> About.
-VERSION = "4.0.1"
+VERSION = "4.0.2"
 
 # Application file paths, relative to the executable's current working directory.
 


### PR DESCRIPTION
## Summary
Revs the application `VERSION` from `4.0.1` to `4.0.2` in `source/constants.py` in preparation for the 4.0.2 release.

`source/constants.py` is the single source of truth for the version — the installer (`scripts/installer.iss` via `package_release.sh`) reads it dynamically and the Help → About / update-check flows surface it, so no other files need changing.

## Test plan
- `pytest tests/*` — all 194 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)